### PR TITLE
Add calendar export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Meal Planner helps users:
 - Avoid repeating meals from recent weeks
 - Create shopping lists for planned meals
 - Manage a collection of recipes with step-by-step instructions
+- Export your meal plan to calendar formats
 
 ## Technology Stack
 
@@ -42,6 +43,8 @@ docker-compose up -d
 yarn
 yarn start
 ```
+
+The weekly plan can be exported as a calendar file from `/api/mealplan/ics` or by clicking the **Add to Google Calendar** button in the Meal Plan tab.
 
 4. Optional: Seed the database with sample data
 ```bash

--- a/backend/handlers/mealplan_ics_test.go
+++ b/backend/handlers/mealplan_ics_test.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"mealplanner/dummy"
+)
+
+func TestMealPlanICSHandler(t *testing.T) {
+	originalUseDummy := UseDummy
+	UseDummy = true
+	defer func() { UseDummy = originalUseDummy }()
+
+	if err := dummy.Load("../Meal_db.csv"); err != nil {
+		t.Fatalf("failed loading dummy data: %v", err)
+	}
+
+	req, err := http.NewRequest("GET", "/api/mealplan/ics", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	rr := httptest.NewRecorder()
+
+	MealPlanICSHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/calendar" {
+		t.Errorf("unexpected content type %s", ct)
+	}
+	if len(rr.Body.String()) == 0 || !strings.Contains(rr.Body.String(), "BEGIN:VCALENDAR") {
+		t.Errorf("invalid ics output")
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -258,6 +258,7 @@ func main() {
 	r.Get("/api/mealplan", handlers.GetMealPlan)
 	r.Post("/api/mealplan/generate", handlers.GenerateMealPlan)
 	r.Post("/api/mealplan/finalize", handlers.FinalizeMealPlanHandler)
+	r.Get("/api/mealplan/ics", handlers.MealPlanICSHandler)
 	r.Post("/api/mealplan/swap", handlers.SwapMeal)
 	r.Post("/api/shoppinglist", handlers.GetShoppingList)
 	r.Get("/api/meals", handlers.GetAllMealsHandler)

--- a/backend/models/mealplan.go
+++ b/backend/models/mealplan.go
@@ -3,6 +3,7 @@ package models
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -189,4 +190,38 @@ func GetLastPlannedMeals(db *sql.DB) (map[string]*Meal, error) {
 	}
 
 	return plan, nil
+}
+
+// MealPlanToICS generates an iCalendar representation of the meal plan starting from the provided monday date.
+// Each meal becomes an all-day event with the meal name as the title.
+func MealPlanToICS(plan map[string]*Meal, monday time.Time) string {
+	weekDays := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+	var b strings.Builder
+	b.WriteString("BEGIN:VCALENDAR\r\n")
+	b.WriteString("VERSION:2.0\r\n")
+	b.WriteString("PRODID:-//Meal Planner//EN\r\n")
+	for i, day := range weekDays {
+		meal, ok := plan[day]
+		if !ok || meal == nil {
+			continue
+		}
+		eventDate := monday.AddDate(0, 0, i)
+		b.WriteString("BEGIN:VEVENT\r\n")
+		b.WriteString("DTSTAMP:" + time.Now().UTC().Format("20060102T150405Z") + "\r\n")
+		b.WriteString("UID:" + fmt.Sprintf("%d-%s@mealplanner", meal.ID, eventDate.Format("20060102")) + "\r\n")
+		b.WriteString("DTSTART;VALUE=DATE:" + eventDate.Format("20060102") + "\r\n")
+		b.WriteString("SUMMARY:" + escapeICSString(meal.MealName) + "\r\n")
+		if meal.URL != "" {
+			b.WriteString("URL:" + meal.URL + "\r\n")
+		}
+		b.WriteString("END:VEVENT\r\n")
+	}
+	b.WriteString("END:VCALENDAR\r\n")
+	return b.String()
+}
+
+// escapeICSString escapes commas and semicolons in strings to conform to the iCalendar format.
+func escapeICSString(s string) string {
+	replacer := strings.NewReplacer(",", "\\,", ";", "\\;", "\n", "\\n")
+	return replacer.Replace(s)
 }

--- a/backend/models/mealplan.go
+++ b/backend/models/mealplan.go
@@ -195,6 +195,7 @@ func GetLastPlannedMeals(db *sql.DB) (map[string]*Meal, error) {
 // MealPlanToICS generates an iCalendar representation of the meal plan starting from the provided monday date.
 // Each meal becomes an all-day event with the meal name as the title.
 func MealPlanToICS(plan map[string]*Meal, monday time.Time) string {
+	monday = monday.UTC().Truncate(24 * time.Hour)
 	weekDays := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
 	var b strings.Builder
 	b.WriteString("BEGIN:VCALENDAR\r\n")

--- a/backend/models/mealplan_ics_test.go
+++ b/backend/models/mealplan_ics_test.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMealPlanToICS(t *testing.T) {
+	plan := map[string]*Meal{
+		"Monday":  {ID: 1, MealName: "Test Meal", URL: "https://example.com"},
+		"Tuesday": {ID: 2, MealName: "Another Meal"},
+	}
+	monday := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	ics := MealPlanToICS(plan, monday)
+
+	if !strings.Contains(ics, "BEGIN:VCALENDAR") {
+		t.Errorf("ics missing calendar header")
+	}
+	if !strings.Contains(ics, "SUMMARY:Test Meal") {
+		t.Errorf("ics missing meal summary")
+	}
+	if !strings.Contains(ics, "URL:https://example.com") {
+		t.Errorf("ics missing meal url")
+	}
+	if !strings.Contains(ics, "DTSTART;VALUE=DATE:20240401") {
+		t.Errorf("ics missing start date")
+	}
+}

--- a/docs/MealPlannerSummary.md
+++ b/docs/MealPlannerSummary.md
@@ -144,6 +144,7 @@ The frontend communicates with the backend through a RESTful API with these key 
 - `/api/meals` - For recipe management
 - `/api/meals/{mealId}/steps` - For recipe step operations
 - `/api/shoppinglist` - For shopping list generation
+- `/api/mealplan/ics` - Export the meal plan as an iCalendar file
 
 ## Core Features
 
@@ -208,6 +209,7 @@ API Endpoints:
 2. **Copy to Clipboard**
    - One-click copying of meal plans for sharing
    - One-click copying of shopping lists
+   - Exporting the meal plan as an `.ics` calendar file
 
 3. **Visual Feedback**
    - Toast notifications for operation success/failure

--- a/frontend/src/components/MealPlanTab.test.tsx
+++ b/frontend/src/components/MealPlanTab.test.tsx
@@ -317,4 +317,23 @@ describe("MealPlanTab", () => {
             value: originalClipboard,
         });
     });
-}); 
+
+    test("opens calendar export", async () => {
+        const openSpy = jest.spyOn(window, "open").mockImplementation(() => null as any);
+
+        await act(async () => {
+            render(<MealPlanTab showToast={mockShowToast} />);
+        });
+
+        await waitForLoadingToComplete();
+
+        const calendarButton = screen.getByText("Add to Google Calendar");
+        await act(async () => {
+            fireEvent.click(calendarButton);
+            jest.advanceTimersByTime(500);
+        });
+
+        expect(openSpy).toHaveBeenCalledWith('/api/mealplan/ics', '_blank');
+        openSpy.mockRestore();
+    });
+});

--- a/frontend/src/components/MealPlanTab.tsx
+++ b/frontend/src/components/MealPlanTab.tsx
@@ -380,6 +380,13 @@ export const MealPlanTab: React.FC<MealPlanTabProps> = ({ showToast }) => {
                 >
                     Get Shopping List
                 </Button>
+                <Button
+                    variant="outlined"
+                    onClick={() => window.open('/api/mealplan/ics', '_blank')}
+                    disabled={!mealPlan}
+                >
+                    Add to Google Calendar
+                </Button>
             </Box>
 
             {shoppingList.length > 0 && (


### PR DESCRIPTION
## Summary
- allow generating `.ics` calendar files
- support `/api/mealplan/ics` endpoint
- open calendar export from the MealPlan tab
- add tests for ICS generation and handler
- document calendar export

## Testing
- `yarn test`