### PR TITLE
Add timeline route skeleton

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.3"
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,8 @@ import { MealPlanTab } from './components/MealPlanTab';
 import { MealManagementTab } from './components/MealManagementTab';
 import { Toast } from './components/Toast';
 import { DatabaseConnectionError } from './components/DatabaseConnectionError';
+import { Routes, Route, useLocation } from 'react-router-dom';
+import Timeline from './components/Timeline';
 
 const App: React.FC = () => {
     const theme = useTheme();
@@ -146,7 +148,7 @@ const App: React.FC = () => {
         return <DatabaseConnectionError onRetry={reconnectDatabase} />;
     }
 
-    return (
+    const MainContent = (
         <Box
             sx={{
                 display: 'flex',
@@ -284,6 +286,13 @@ const App: React.FC = () => {
 
             <Toast message={toast} />
         </Box>
+    );
+
+    return (
+        <Routes>
+            <Route path="/timeline" element={<Timeline />} />
+            <Route path="*" element={MainContent} />
+        </Routes>
     );
 };
 

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+import { format, addDays, startOfWeek } from 'date-fns';
+
+const daysOfWeek = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+
+export const Timeline: React.FC = () => {
+  const start = startOfWeek(new Date(), { weekStartsOn: 1 });
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, p: 2 }}>
+      {daysOfWeek.map((day, index) => (
+        <Paper key={day} sx={{ p: 2 }}>
+          <Typography variant="h6">
+            {day} ({format(addDays(start, index), 'MMM d')})
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Timeline placeholder for {day}
+          </Typography>
+        </Paper>
+      ))}
+    </Box>
+  );
+};
+
+export default Timeline;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from './theme';
+import { BrowserRouter } from 'react-router-dom';
 
 // Add Google Fonts
 const fontLink = document.createElement('link');
@@ -20,10 +21,12 @@ try {
     const root = ReactDOM.createRoot(rootElement);
     root.render(
         <React.StrictMode>
-            <ThemeProvider theme={theme}>
-                <CssBaseline />
-                <App />
-            </ThemeProvider>
+            <BrowserRouter>
+                <ThemeProvider theme={theme}>
+                    <CssBaseline />
+                    <App />
+                </ThemeProvider>
+            </BrowserRouter>
         </React.StrictMode>
     );
 } catch (error) {


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- wrap app in `BrowserRouter`
- render `Timeline` component at `/timeline`
- create simple `Timeline` placeholder component

## Testing
- `yarn test:backend`
- `yarn test:frontend` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6845e1f08484832483ee7c229f3f7860