### PR TITLE
Switch MCP server from SSE to stdio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### MCP Server Development
 - `cd backend/mcp && yarn build` - Build MCP TypeScript server
-- `cd backend/mcp && yarn start` - Run built MCP server (port 3001)
+- `cd backend/mcp && yarn start` - Run built MCP server (stdio)
 - `cd backend/mcp && yarn dev` - Run MCP server in development mode with nodemon
 - `cd backend/mcp && yarn test` - Run MCP server tests
 
@@ -52,14 +52,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### MCP Server (TypeScript)
 - **Location**: `backend/mcp/` - TypeScript MCP server implementation
-- **Port**: 3001 (separate from main Go backend)
-- **Framework**: Express.js with CORS enabled
-- **Protocol**: Model Context Protocol with SSE transport
+- **Transport**: Standard input/output (stdio)
+- **Framework**: none (uses MCP SDK directly)
+- **Protocol**: Model Context Protocol
 - **Tools**: Currently implements basic "hello" tool as scaffold
 - **Validation**: Uses Zod for input validation
-- **Endpoints**: 
-  - `/health` - Health check
-  - `/sse` - Server-Sent Events for MCP communication
 - **Testing**: Jest with comprehensive tool logic tests
 
 ### Key Features

--- a/backend/mcp/README.md
+++ b/backend/mcp/README.md
@@ -9,15 +9,13 @@ cd backend/mcp
 yarn build
 NODE_ENV=production BACKEND_BASE_URL=http://localhost:8080 node dist/index.js
 ```
-
-The server listens on `MCP_PORT` (default `3001`).
+The server communicates via standard input/output.
 
 ## Environment variables
 
 | Name | Default | Purpose |
 |------|---------|---------|
 | `BACKEND_BASE_URL` | `http://localhost:8080` | Go API root |
-| `MCP_PORT` | `3001` | HTTP/SSE listen port |
 
 ## Resources
 - **WeeklyMealPlan** – `GET /api/mealplan`

--- a/backend/mcp/src/index.ts
+++ b/backend/mcp/src/index.ts
@@ -1,8 +1,5 @@
-import express from 'express';
-import cors from 'cors';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { MCP_PORT } from './utils.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerWeeklyMealPlan } from './resources/weeklyMealPlan.js';
 import { registerRecipes } from './resources/recipes.js';
 import { registerRecipeSteps } from './resources/recipeSteps.js';
@@ -14,9 +11,6 @@ import { registerGenerateShoppingList } from './tools/generateShoppingList.js';
 import { registerCreateRecipe } from './tools/createRecipe.js';
 import { registerDeleteRecipe } from './tools/deleteRecipe.js';
 
-const app = express();
-app.use(cors());
-app.use(express.json());
 
 const server = new McpServer({ name: 'mealplanner-mcp', version: '1.0.0' });
 
@@ -32,29 +26,13 @@ registerGenerateShoppingList(server);
 registerCreateRecipe(server);
 registerDeleteRecipe(server);
 
-app.get('/health', (req, res) => {
-  res.json({ status: 'healthy', timestamp: new Date().toISOString() });
-});
-
-const transports: Record<string, SSEServerTransport> = {};
-
-app.get('/sse', async (req, res) => {
-  const transport = new SSEServerTransport('/messages', res);
-  transports[transport.sessionId] = transport;
-  transport.onclose = () => { delete transports[transport.sessionId]; };
+async function main() {
+  const transport = new StdioServerTransport();
   await server.connect(transport);
-});
+  console.error('MealPlanner MCP server running on stdio');
+}
 
-app.post('/messages', async (req, res) => {
-  const sessionId = req.query.sessionId as string;
-  const transport = transports[sessionId];
-  if (!transport) {
-    res.status(404).send('Session not found');
-    return;
-  }
-  await transport.handlePostMessage(req, res, req.body);
-});
-
-app.listen(MCP_PORT, () => {
-  console.error(`MealPlanner MCP server running on http://localhost:${MCP_PORT}`);
+main().catch((err) => {
+  console.error('Server error:', err);
+  process.exit(1);
 });

--- a/backend/mcp/src/utils.ts
+++ b/backend/mcp/src/utils.ts
@@ -1,2 +1,1 @@
 export const API = process.env.BACKEND_BASE_URL || 'http://localhost:8080';
-export const MCP_PORT = parseInt(process.env.MCP_PORT || '3001', 10);

--- a/mcp-server-codex-prompt.md
+++ b/mcp-server-codex-prompt.md
@@ -44,7 +44,6 @@ backend/
 
 ENV var	Default	Purpose
 BACKEND_BASE_URL	http://localhost:8080	Go API root
-MCP_PORT	3001	HTTP/SSE listen port
 
 No other configuration exists.
 If the Go API port changes, only update BACKEND_BASE_URL.
@@ -112,7 +111,6 @@ new MCPServer({
   resources: [WeeklyMealPlan, Recipes, RecipeSteps],
   tools: [generateMealPlan, finalizeMealPlan, swapMeal, replaceMeal,
           generateShoppingList, createRecipe, deleteRecipe],
-}).listen(MCP_PORT);
 ```
 
 	5.	Unit tests (tests/)
@@ -149,14 +147,13 @@ The foundational MCP server infrastructure has been implemented:
 
 - ✅ **MCP Directory Structure**: Created `backend/mcp/` with proper workspace integration
 - ✅ **Package Configuration**: Initialized with "mealplanner-mcp" v1.0.0, ES modules, TypeScript
-- ✅ **Dependencies Installed**: Official MCP SDK, Express, CORS, TypeScript tooling, Jest
+- ✅ **Dependencies Installed**: Official MCP SDK, TypeScript tooling, Jest
 - ✅ **TypeScript Setup**: Configured with ES2022 target and proper module resolution
-- ✅ **HTTP+SSE Transport**: Implemented MCP server with Express on port 3001 (not stdio)
+- ✅ **Stdio Transport**: MCP server connects via standard input/output (no HTTP server)
 - ✅ **Hello World Tool**: Basic "hello" tool for testing MCP functionality
-- ✅ **Test Suite**: Jest-based tests for HTTP server and MCP tool logic
-- ✅ **Health Check**: HTTP endpoint at `/health` for monitoring
+- ✅ **Test Suite**: Jest-based tests for MCP tool logic
 
-**Current Status**: The MCP server runs at `http://localhost:3001` with SSE endpoint at `/sse`. The hello world tool is functional and tested. Ready for meal planner integration.
+**Current Status**: The MCP server runs over stdio. The hello world tool is functional and tested. Ready for meal planner integration.
 
 ### Example MCP Tool Definitions
 Below are six high-quality, example tool implementations.


### PR DESCRIPTION
## Summary
- run MCP server via StdioServerTransport instead of Express/SSE
- drop MCP_PORT usage and update utils
- document stdio usage in README and CLAUDE
- update docs about MCP server transport

## Testing
- `yarn test` *(fails: frontend test suite did not run)*

------
https://chatgpt.com/codex/tasks/task_e_684db8fefbb88324b9f2a4837cbbf87a