### PR TITLE
Implement MealPlanner agent loop

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -30,15 +30,25 @@ const WeeklyMealPlanSchema = z.object({
 
 type WeeklyMealPlan = z.infer<typeof WeeklyMealPlanSchema>;
 
+const DAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
 class MealPlannerAgent {
   private client: Client;
   private agent: any = null;
 
-  constructor() {
-    // Initialize MCP client with stdio transport
-    this.client = new Client({
+  constructor(client?: Client) {
+    // Allow injecting a custom MCP client for testing
+    this.client = client ?? new Client({
       name: "meal-planner-agent",
-      version: "1.0.0"
+      version: "1.0.0",
     });
   }
 
@@ -122,14 +132,64 @@ class MealPlannerAgent {
   }
 
   async generateOptimalMealPlan(): Promise<WeeklyMealPlan> {
-    // TODO: Implement the ReACT loop from plan.md
-    // 1. Generate initial plan
-    // 2. Validate against criteria
-    // 3. Replace problematic meals
-    // 4. Repeat until satisfied
-    // 5. Return final plan
-    
-    throw new Error("Implementation needed: generateOptimalMealPlan");
+    // Generate an initial meal plan using the MCP tool
+    const planResult = await this.client.callTool({
+      name: 'generateMealPlan',
+      arguments: {}
+    });
+
+    let plan = WeeklyMealPlanSchema.parse(
+      JSON.parse(planResult.content[0].text)
+    );
+
+    let issues = this.validatePlan(plan);
+    let attempts = 0;
+
+    while (issues.length > 0 && attempts < 3) {
+      // Fetch available meals and pick a kid-friendly option not already used
+      const mealsResp = await this.client.callTool({
+        name: 'getMeals',
+        arguments: {}
+      });
+      const meals: any[] = JSON.parse(mealsResp.content[0].text);
+      const used = new Set(plan.days.map(d => d.meal.id));
+      const candidate = meals.find(
+        m => m.relativeEffort <= 2 && !m.redMeat && !used.has(m.id)
+      );
+      if (!candidate) {
+        break;
+      }
+
+      // Pick the first day with a reported issue
+      const targetDay = plan.days.find(
+        d =>
+          d.meal.effort > 3 ||
+          d.meal.hasRedMeat && issues.some(i => i.includes('red meat')) ||
+          issues.some(i => i.includes(`${d.meal.id}`))
+      );
+      if (!targetDay) {
+        break;
+      }
+
+      const dayName = DAY_NAMES[targetDay.dayIndex];
+      const replaceResp = await this.client.callTool({
+        name: 'replaceMeal',
+        arguments: {
+          day: dayName,
+          mealType: 'dinner',
+          newMealId: candidate.id
+        }
+      });
+
+      plan = WeeklyMealPlanSchema.parse(
+        JSON.parse(replaceResp.content[0].text)
+      );
+
+      issues = this.validatePlan(plan);
+      attempts++;
+    }
+
+    return plan;
   }
 
   async cleanup() {

--- a/agent/jest.config.js
+++ b/agent/jest.config.js
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts'],
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: ['**/tests/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { useESM: true }]
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};

--- a/agent/package.json
+++ b/agent/package.json
@@ -6,7 +6,8 @@
     "dev": "tsx watch --env-file=.env agent.ts",
     "dev:codex": "tsx watch --env-file=.env agent.ts --codex",
     "build": "tsc",
-    "start": "node --env-file=.env dist/agent.js"
+    "start": "node --env-file=.env dist/agent.js",
+    "test": "jest"
   },
   "dependencies": {
     "@langchain/core": "^0.2.0",
@@ -17,6 +18,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/jest": "^29.5.4",
+    "jest": "^30.0.0",
+    "ts-jest": "^29.1.1",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"
   }

--- a/agent/tests/generateOptimalMealPlan.test.ts
+++ b/agent/tests/generateOptimalMealPlan.test.ts
@@ -1,0 +1,57 @@
+import { MealPlannerAgent } from '../agent.js';
+import { jest } from '@jest/globals';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+function makeClient(mockResponses: Record<string, any>): Client {
+  return {
+    callTool: jest.fn(({ name }) => Promise.resolve(mockResponses[name])),
+    close: jest.fn(),
+  } as unknown as Client;
+}
+
+describe('MealPlannerAgent.generateOptimalMealPlan', () => {
+  it('returns plan when no issues detected', async () => {
+    const plan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 2, hasRedMeat: false } },
+      ]
+    };
+    const client = makeClient({
+      generateMealPlan: { content: [{ type: 'text', text: JSON.stringify(plan) }] }
+    });
+    const agent = new MealPlannerAgent(client);
+
+    const result = await agent.generateOptimalMealPlan();
+    expect(result).toEqual(plan);
+    expect((client.callTool as jest.Mock).mock.calls[0][0].name).toBe('generateMealPlan');
+  });
+
+  it('attempts replacement when issues exist', async () => {
+    const initialPlan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 5, hasRedMeat: false } },
+        { dayIndex: 1, meal: { id: 1, name: 'A', effort: 5, hasRedMeat: false } },
+      ]
+    };
+    const replacedPlan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 5, hasRedMeat: false } },
+        { dayIndex: 1, meal: { id: 2, name: 'B', effort: 1, hasRedMeat: false } },
+      ]
+    };
+    const meals = [
+      { id: 2, mealName: 'B', relativeEffort: 1, redMeat: false }
+    ];
+    const client = makeClient({
+      generateMealPlan: { content: [{ type: 'text', text: JSON.stringify(initialPlan) }] },
+      getMeals: { content: [{ type: 'text', text: JSON.stringify(meals) }] },
+      replaceMeal: { content: [{ type: 'text', text: JSON.stringify(replacedPlan) }] },
+    });
+
+    const agent = new MealPlannerAgent(client);
+    const result = await agent.generateOptimalMealPlan();
+
+    expect(result).toEqual(replacedPlan);
+    expect((client.callTool as jest.Mock).mock.calls.some(c => c[0].name === 'replaceMeal')).toBe(true);
+  });
+});

--- a/agent/tests/validatePlan.test.ts
+++ b/agent/tests/validatePlan.test.ts
@@ -1,0 +1,53 @@
+import { MealPlannerAgent, VALIDATION_CRITERIA } from '../agent.js';
+
+const basePlan = {
+  days: [
+    { dayIndex: 0, meal: { id: 1, name: 'A', effort: 2, hasRedMeat: false } },
+    { dayIndex: 1, meal: { id: 2, name: 'B', effort: 2, hasRedMeat: false } },
+    { dayIndex: 2, meal: { id: 3, name: 'C', effort: 2, hasRedMeat: false } },
+  ]
+};
+
+describe('MealPlannerAgent.validatePlan', () => {
+  const agent = new MealPlannerAgent();
+
+  it('detects consecutive high effort meals', () => {
+    const plan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 4, hasRedMeat: false } },
+        { dayIndex: 1, meal: { id: 2, name: 'B', effort: 4, hasRedMeat: false } },
+        { dayIndex: 2, meal: { id: 3, name: 'C', effort: 4, hasRedMeat: false } },
+      ]
+    };
+    const issues = agent.validatePlan(plan as any);
+    expect(issues).toContain(
+      `Too many consecutive high-effort meals (day 2)`
+    );
+  });
+
+  it('detects too much red meat', () => {
+    const plan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 2, hasRedMeat: true } },
+        { dayIndex: 1, meal: { id: 2, name: 'B', effort: 2, hasRedMeat: true } },
+        { dayIndex: 2, meal: { id: 3, name: 'C', effort: 2, hasRedMeat: true } },
+        { dayIndex: 3, meal: { id: 4, name: 'D', effort: 2, hasRedMeat: true } },
+      ]
+    };
+    const issues = agent.validatePlan(plan as any);
+    expect(issues).toContain(
+      `Too many red meat meals: 4 (max ${VALIDATION_CRITERIA.maxRedMeatPerWeek})`
+    );
+  });
+
+  it('detects duplicate meals', () => {
+    const plan = {
+      days: [
+        { dayIndex: 0, meal: { id: 1, name: 'A', effort: 2, hasRedMeat: false } },
+        { dayIndex: 1, meal: { id: 1, name: 'A', effort: 2, hasRedMeat: false } },
+      ]
+    };
+    const issues = agent.validatePlan(plan as any);
+    expect(issues).toContain('Duplicate meals found: 1');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "start:mcp": "node scripts/start-mcp.js",
         "test:backend": "cd backend && go test -v ./...",
         "test:frontend": "cd frontend && yarn test",
+        "test:agent": "cd agent && yarn test",
         "test": "node scripts/test-summary.js",
         "db:backup": "node scripts/backup-db.js",
         "db:restore": "node scripts/restore-db.js",


### PR DESCRIPTION
## Summary
- implement generateOptimalMealPlan in agent
- allow injecting MCP client
- add test suite for agent logic
- configure Jest for the agent workspace
- expose `test:agent` script

## Testing
- `yarn test` *(fails: Frontend tests failed)*
- `yarn test:agent` *(fails: command not found: jest)*

------
https://chatgpt.com/codex/tasks/task_e_684e20cff7d48324bbb16e982b7a22da