### PR TITLE
Fix agent chat page

### DIFF
--- a/frontend/src/AgentPage.test.tsx
+++ b/frontend/src/AgentPage.test.tsx
@@ -11,15 +11,67 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
+test('copies meal plan to clipboard', async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({
+      threadId: '123',
+      currentStep: 'started',
+      message: 'hi',
+      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
+    })
+  });
+
+  const write = jest.fn();
+  Object.assign(navigator, { clipboard: { write, writeText: write } });
+  // Mock ClipboardItem constructor
+  (global as any).ClipboardItem = jest.fn().mockImplementation(data => ({ data }));
+
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId('start-session'));
+
+  await waitFor(() => expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByTestId('copy-meal-plan'));
+  expect(write).toHaveBeenCalled();
+});
+
+test('copies shopping list to clipboard', async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({
+      threadId: '123',
+      currentStep: 'started',
+      message: 'hi',
+      raw: { meal_plan: { days: [] }, shopping_list_formatted: '- eggs\n' }
+    })
+  });
+
+  const writeText = jest.fn();
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId('start-session'));
+
+  await waitFor(() => expect(screen.getByTestId('copy-shopping-list')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByTestId('copy-shopping-list'));
+  expect(writeText).toHaveBeenCalledWith('- eggs\n');
+});
+
 test('starts a new session', async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({ threadId: '123', currentStep: 'started', message: 'hi' })
+    json: () => Promise.resolve({
+      threadId: '123',
+      currentStep: 'started',
+      message: 'hi',
+      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
+    })
   });
   render(<AgentPage />);
   fireEvent.click(screen.getByTestId('start-session'));
   await waitFor(() => {
     expect(global.fetch).toHaveBeenCalledWith('/api/agent/start', expect.any(Object));
     expect(screen.getByTestId('session-id')).toHaveTextContent('123');
+    expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument();
   });
 });
 
@@ -35,14 +87,22 @@ test('sends a message in an existing session', async () => {
   // feedback response
   (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
   // resume response
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok' }) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok', raw: { meal_plan: { days: [] } } }) });
 
   fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'hello' } });
   fireEvent.click(screen.getByTestId('send-button'));
 
   await waitFor(() => {
-    expect(global.fetch).toHaveBeenCalledWith('/api/agent/feedback', expect.any(Object));
-    expect(global.fetch).toHaveBeenCalledWith('/api/agent/resume', expect.any(Object));
+    const feedbackCall = (global.fetch as jest.Mock).mock.calls.find(c => c[0] === '/api/agent/feedback');
+    const resumeCall = (global.fetch as jest.Mock).mock.calls.find(c => c[0] === '/api/agent/resume');
+    expect(feedbackCall).toBeTruthy();
+    expect(resumeCall).toBeTruthy();
+    if (feedbackCall) {
+      expect(JSON.parse(feedbackCall[1].body).threadId).toBe('123');
+    }
+    if (resumeCall) {
+      expect(JSON.parse(resumeCall[1].body).threadId).toBe('123');
+    }
     expect(screen.getByText('agent: ok')).toBeInTheDocument();
   });
 });

--- a/frontend/src/AgentPage.tsx
+++ b/frontend/src/AgentPage.tsx
@@ -1,5 +1,40 @@
 import React, { useState } from 'react';
 import { Box, Button, TextField, List, ListItem, Typography } from '@mui/material';
+import MealPlanDisplay, { WeeklyMealPlan } from './components/MealPlanDisplay';
+
+// Utility to format a WeeklyMealPlan for clipboard copying
+const WEEK_DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+function formatMealPlan(plan: WeeklyMealPlan): { html: string; text: string } {
+  let html = '<table style="border-collapse: collapse; width: 100%;">';
+  html += '<thead><tr>' +
+          '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Day</th>' +
+          '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Meals</th>' +
+          '</tr></thead><tbody>';
+
+  let text = 'Day | Meals\n';
+  text += '----|------\n';
+
+  WEEK_DAYS.forEach((day, idx) => {
+    const entries = plan.days.filter(d => d.dayIndex === idx);
+    if (entries.length === 0) return;
+
+    const mealsHtml = entries.map(e => {
+      const meal = e.meal;
+      return `<strong>${e.mealType.charAt(0).toUpperCase()+e.mealType.slice(1)}</strong>: ${meal.name} (${meal.effort})`;
+    }).join('<br>');
+    html += `<tr><td style="border:1px solid #ddd;padding:8px;">${day}</td>` +
+            `<td style="border:1px solid #ddd;padding:8px;">${mealsHtml}</td></tr>`;
+
+    const mealsText = entries.map(e => {
+      const meal = e.meal;
+      return `${e.mealType}: ${meal.name} (${meal.effort})`;
+    }).join('; ');
+    text += `${day} | ${mealsText}\n`;
+  });
+
+  html += '</tbody></table>';
+  return { html, text };
+}
 
 interface ChatMessage {
   sender: 'user' | 'agent';
@@ -16,7 +51,8 @@ const AgentPage: React.FC = () => {
   const [input, setInput] = useState('');
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [isWorking, setIsWorking] = useState(false);
-  const [mealPlan, setMealPlan] = useState<any | null>(null);
+  const [mealPlan, setMealPlan] = useState<WeeklyMealPlan | null>(null);
+  const [shoppingList, setShoppingList] = useState<string | null>(null);
 
   const startSession = async () => {
     setIsWorking(true);
@@ -28,7 +64,9 @@ const AgentPage: React.FC = () => {
       });
       const data = await res.json();
       setSession({ threadId: data.threadId, currentStep: data.currentStep });
-      if (data.meal_plan) setMealPlan(data.meal_plan);
+      const plan = data.raw?.meal_plan || data.initialState?.meal_plan || data.meal_plan;
+      if (plan) setMealPlan(plan);
+      if (data.raw?.shopping_list_formatted) setShoppingList(data.raw.shopping_list_formatted);
       if (data.message) setMessages([{ sender: 'agent', text: data.message }]);
     } catch (err) {
       console.error('Failed to start session', err);
@@ -47,21 +85,41 @@ const AgentPage: React.FC = () => {
       await fetch('/api/agent/feedback', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ thread_id: session.threadId, message: userMsg.text, from: 'user' })
+        body: JSON.stringify({ threadId: session.threadId, message: userMsg.text, from: 'user' })
       });
       const res = await fetch('/api/agent/resume', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ thread_id: session.threadId, interactive: false })
+        body: JSON.stringify({ threadId: session.threadId, interactive: false })
       });
       const data = await res.json();
       if (data.message) setMessages(prev => [...prev, { sender: 'agent', text: data.message }]);
       if (data.raw && data.raw.meal_plan) setMealPlan(data.raw.meal_plan);
+      if (data.raw && data.raw.shopping_list_formatted) setShoppingList(data.raw.shopping_list_formatted);
     } catch (err) {
       console.error('Failed to send message', err);
     } finally {
       setIsWorking(false);
     }
+  };
+
+  const copyMealPlan = () => {
+    if (!mealPlan) return;
+    const { html, text } = formatMealPlan(mealPlan);
+    try {
+      const item = new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([text], { type: 'text/plain' })
+      });
+      navigator.clipboard.write([item]);
+    } catch (e) {
+      navigator.clipboard.writeText(text);
+    }
+  };
+
+  const copyShoppingList = () => {
+    if (!shoppingList) return;
+    navigator.clipboard.writeText(shoppingList);
   };
 
   return (
@@ -76,7 +134,13 @@ const AgentPage: React.FC = () => {
         ))}
       </List>
       {mealPlan && (
-        <pre data-testid="meal-plan">{JSON.stringify(mealPlan)}</pre>
+        <>
+          <MealPlanDisplay plan={mealPlan} />
+          <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
+            <Button variant="outlined" onClick={copyMealPlan} data-testid="copy-meal-plan">Copy Meal Plan</Button>
+            {shoppingList && <Button variant="outlined" onClick={copyShoppingList} data-testid="copy-shopping-list">Copy Shopping List</Button>}
+          </Box>
+        </>
       )}
       <TextField 
         value={input}

--- a/frontend/src/components/MealPlanDisplay.tsx
+++ b/frontend/src/components/MealPlanDisplay.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+interface MealInfo {
+  id: number;
+  name: string;
+  effort: number;
+  hasRedMeat?: boolean;
+}
+
+interface DayEntry {
+  dayIndex: number;
+  mealType: string;
+  meal: MealInfo;
+}
+
+export interface WeeklyMealPlan {
+  days: DayEntry[];
+}
+
+const WEEK_DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+
+const effortIcons = ['','🔥','🔥🔥','🔥🔥🔥'];
+
+export const MealPlanDisplay: React.FC<{ plan: WeeklyMealPlan }> = ({ plan }) => {
+  const grouped = WEEK_DAYS.map((day, idx) => {
+    const entries = plan.days.filter(d => d.dayIndex === idx);
+    return { day, entries };
+  });
+
+  return (
+    <table data-testid="meal-plan-table" style={{ borderCollapse: 'collapse', width: '100%' }}>
+      <thead>
+        <tr>
+          <th style={{ border: '1px solid #ddd', padding: 4, textAlign: 'left' }}>Day</th>
+          <th style={{ border: '1px solid #ddd', padding: 4, textAlign: 'left' }}>Meals</th>
+        </tr>
+      </thead>
+      <tbody>
+        {grouped.map(({ day, entries }) => (
+          entries.length > 0 ? (
+            <tr key={day}>
+              <td style={{ border: '1px solid #ddd', padding: 4 }}>{day}</td>
+              <td style={{ border: '1px solid #ddd', padding: 4 }}>
+                {entries.map(e => (
+                  <div key={e.mealType}>
+                    <strong>{e.mealType.charAt(0).toUpperCase()+e.mealType.slice(1)}:</strong> {e.meal.name}
+                    {' '}{effortIcons[e.meal.effort]}
+                    {e.meal.hasRedMeat && ' 🥩'}
+                  </div>
+                ))}
+              </td>
+            </tr>
+          ) : null
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default MealPlanDisplay;


### PR DESCRIPTION
## Summary
- display generated meal plan in the `/agent` chat page
- pass `threadId` in feedback/resume requests
- test `threadId` usage and meal plan output
- add copy buttons for meal plan and shopping list

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68534c7b6b08832492a84cbbeb6e39d0