### PR TITLE
Improve agent chat UI and meal plan highlights

### DIFF
--- a/frontend/src/AgentPage.test.tsx
+++ b/frontend/src/AgentPage.test.tsx
@@ -82,7 +82,7 @@ test('sends a message in an existing session', async () => {
   });
   render(<AgentPage />);
   fireEvent.click(screen.getByTestId('start-session'));
-  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByTestId('message-input')).toBeInTheDocument());
 
   // feedback response
   (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
@@ -103,6 +103,44 @@ test('sends a message in an existing session', async () => {
     if (resumeCall) {
       expect(JSON.parse(resumeCall[1].body).threadId).toBe('123');
     }
-    expect(screen.getByText('agent: ok')).toBeInTheDocument();
+    expect(screen.getByText('ok')).toBeInTheDocument();
   });
+});
+
+test('pressing Enter sends the message', async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ threadId: '123', currentStep: 'started' }) });
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId('start-session'));
+  await waitFor(() => expect(screen.getByTestId('message-input')).toBeInTheDocument());
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok', raw: { meal_plan: { days: [] } } }) });
+
+  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'hello' } });
+  fireEvent.keyPress(screen.getByTestId('message-input'), { key: 'Enter', code: 'Enter', charCode: 13 });
+
+  await waitFor(() => expect(screen.getByText('ok')).toBeInTheDocument());
+});
+
+test('highlights changed meal plan entries', async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({
+      threadId: '123',
+      currentStep: 'started',
+      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
+    })
+  });
+
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId('start-session'));
+
+  await waitFor(() => expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument());
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok', raw: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 2, name: 'Pancakes', effort: 1 } } ] } } }) });
+
+  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'change' } });
+  fireEvent.click(screen.getByTestId('send-button'));
+
+  await waitFor(() => expect(screen.getByTestId('meal-0-breakfast').style.animation).not.toBe('')); 
 });

--- a/frontend/src/AgentPage.tsx
+++ b/frontend/src/AgentPage.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { Box, Button, TextField, List, ListItem, Typography } from '@mui/material';
+import React, { useState, useRef, useEffect } from 'react';
+import { Box, Button, TextField, Typography, Paper, Avatar, IconButton } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
 import MealPlanDisplay, { WeeklyMealPlan } from './components/MealPlanDisplay';
 
 // Utility to format a WeeklyMealPlan for clipboard copying
@@ -53,6 +54,40 @@ const AgentPage: React.FC = () => {
   const [isWorking, setIsWorking] = useState(false);
   const [mealPlan, setMealPlan] = useState<WeeklyMealPlan | null>(null);
   const [shoppingList, setShoppingList] = useState<string | null>(null);
+  const [highlights, setHighlights] = useState<Set<string>>(new Set());
+  const chatRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = chatRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
+
+  const applyHighlights = (newPlan: WeeklyMealPlan) => {
+    setHighlights(prev => {
+      const changed = new Set<string>();
+      if (mealPlan) {
+        newPlan.days.forEach(d => {
+          const prevEntry = mealPlan.days.find(p => p.dayIndex === d.dayIndex && p.mealType === d.mealType);
+          if (!prevEntry || prevEntry.meal.id !== d.meal.id) {
+            changed.add(`${d.dayIndex}-${d.mealType}`);
+          }
+        });
+      }
+      if (changed.size > 0) {
+        setTimeout(() => {
+          setHighlights(h => {
+            const copy = new Set(h);
+            changed.forEach(k => copy.delete(k));
+            return copy;
+          });
+        }, 5000);
+      }
+      return new Set([...prev, ...changed]);
+    });
+    setMealPlan(newPlan);
+  };
 
   const startSession = async () => {
     setIsWorking(true);
@@ -94,7 +129,7 @@ const AgentPage: React.FC = () => {
       });
       const data = await res.json();
       if (data.message) setMessages(prev => [...prev, { sender: 'agent', text: data.message }]);
-      if (data.raw && data.raw.meal_plan) setMealPlan(data.raw.meal_plan);
+      if (data.raw && data.raw.meal_plan) applyHighlights(data.raw.meal_plan);
       if (data.raw && data.raw.shopping_list_formatted) setShoppingList(data.raw.shopping_list_formatted);
     } catch (err) {
       console.error('Failed to send message', err);
@@ -122,32 +157,58 @@ const AgentPage: React.FC = () => {
     navigator.clipboard.writeText(shoppingList);
   };
 
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      sendMessage();
+    }
+  };
+
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Button onClick={startSession} variant="contained" data-testid="start-session">Start New Session</Button>
       {session && (
-        <Typography sx={{ mt: 2 }} data-testid="session-id">Session: {session.threadId}</Typography>
+        <Typography data-testid="session-id">Session: {session.threadId}</Typography>
       )}
-      <List data-testid="chat-history">
+      <Box ref={chatRef} data-testid="chat-history" sx={{ flexGrow: 1, overflowY: 'auto', maxHeight: 300, display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
         {messages.map((m, i) => (
-          <ListItem key={i}>{m.sender}: {m.text}</ListItem>
+          <Box key={i} sx={{ display: 'flex', justifyContent: m.sender === 'user' ? 'flex-end' : 'flex-start' }}>
+            <Paper sx={{ p: 1, maxWidth: '70%', backgroundColor: m.sender === 'user' ? '#eef4ea' : '#fff' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {m.sender === 'agent' && <Avatar sx={{ width: 24, height: 24 }}>A</Avatar>}
+                <Typography variant="body2">{m.text}</Typography>
+                {m.sender === 'user' && <Avatar sx={{ width: 24, height: 24 }}>U</Avatar>}
+              </Box>
+            </Paper>
+          </Box>
         ))}
-      </List>
+      </Box>
       {mealPlan && (
         <>
-          <MealPlanDisplay plan={mealPlan} />
+          <MealPlanDisplay plan={mealPlan} highlights={highlights} />
           <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
             <Button variant="outlined" onClick={copyMealPlan} data-testid="copy-meal-plan">Copy Meal Plan</Button>
             {shoppingList && <Button variant="outlined" onClick={copyShoppingList} data-testid="copy-shopping-list">Copy Shopping List</Button>}
           </Box>
         </>
       )}
-      <TextField 
-        value={input}
-        onChange={e => setInput(e.target.value)}
-        inputProps={{ 'data-testid': 'message-input' }}
-      />
-      <Button onClick={sendMessage} disabled={!session || !input} data-testid="send-button">Send</Button>
+      {session && (
+        <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+          <TextField
+            fullWidth
+            multiline
+            minRows={1}
+            maxRows={4}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyPress={handleKeyPress}
+            inputProps={{ 'data-testid': 'message-input' }}
+          />
+          <IconButton color="primary" onClick={sendMessage} disabled={!input.trim()} data-testid="send-button">
+            <SendIcon />
+          </IconButton>
+        </Box>
+      )}
       {isWorking && <Typography data-testid="working">Working...</Typography>}
     </Box>
   );

--- a/frontend/src/components/MealPlanDisplay.tsx
+++ b/frontend/src/components/MealPlanDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { keyframes } from '@mui/system';
 
 interface MealInfo {
   id: number;
@@ -21,7 +22,17 @@ const WEEK_DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','
 
 const effortIcons = ['','🔥','🔥🔥','🔥🔥🔥'];
 
-export const MealPlanDisplay: React.FC<{ plan: WeeklyMealPlan }> = ({ plan }) => {
+interface MealPlanDisplayProps {
+  plan: WeeklyMealPlan;
+  highlights?: Set<string>;
+}
+
+const fade = keyframes`
+  from { background-color: #e6f4ea; }
+  to { background-color: transparent; }
+`;
+
+export const MealPlanDisplay: React.FC<MealPlanDisplayProps> = ({ plan, highlights }) => {
   const grouped = WEEK_DAYS.map((day, idx) => {
     const entries = plan.days.filter(d => d.dayIndex === idx);
     return { day, entries };
@@ -41,13 +52,21 @@ export const MealPlanDisplay: React.FC<{ plan: WeeklyMealPlan }> = ({ plan }) =>
             <tr key={day}>
               <td style={{ border: '1px solid #ddd', padding: 4 }}>{day}</td>
               <td style={{ border: '1px solid #ddd', padding: 4 }}>
-                {entries.map(e => (
-                  <div key={e.mealType}>
-                    <strong>{e.mealType.charAt(0).toUpperCase()+e.mealType.slice(1)}:</strong> {e.meal.name}
-                    {' '}{effortIcons[e.meal.effort]}
-                    {e.meal.hasRedMeat && ' 🥩'}
-                  </div>
-                ))}
+                {entries.map(e => {
+                  const key = `${e.dayIndex}-${e.mealType}`;
+                  const isHighlighted = highlights?.has(key);
+                  return (
+                    <div
+                      key={e.mealType}
+                      data-testid={`meal-${key}`}
+                      style={isHighlighted ? { animation: `${fade} 5s forwards` } : {}}
+                    >
+                      <strong>{e.mealType.charAt(0).toUpperCase()+e.mealType.slice(1)}:</strong> {e.meal.name}
+                      {' '}{effortIcons[e.meal.effort]}
+                      {e.meal.hasRedMeat && ' 🥩'}
+                    </div>
+                  );
+                })}
               </td>
             </tr>
           ) : null


### PR DESCRIPTION
## Summary
- overhaul AgentPage UI with chat bubbles, avatars, multiline input and scroll handling
- add meal plan change highlighting via CSS animation
- update AgentPage tests for new UI

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685358e466bc8324b4f15a0d7e6bdfc3