### PR TITLE
Implement auto-resume session flow

### DIFF
--- a/backend/handlers/workflows.go
+++ b/backend/handlers/workflows.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"mealplanner/models"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// in-memory map to track workflow status like ABANDONED
+var workflowStatus = make(map[string]string)
+
+// GetWorkflowState handles GET /api/workflows/{threadId}
+func GetWorkflowState(w http.ResponseWriter, r *http.Request) {
+	threadID := chi.URLParam(r, "threadId")
+	if threadID == "" {
+		http.Error(w, "missing thread id", http.StatusBadRequest)
+		return
+	}
+
+	state := models.WorkflowState{ThreadID: threadID, Status: "ACTIVE"}
+	if s, ok := workflowStatus[threadID]; ok {
+		state.Status = s
+	}
+
+	if !UseDummy {
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		resp, err := runAgentCLI(ctx, "status", threadID)
+		if err == nil {
+			state.CurrentStep = resp.CurrentStep
+		}
+	}
+
+	writeJSON(w, state)
+}
+
+// AbandonWorkflow handles POST /api/workflows/{threadId}/abandon
+func AbandonWorkflow(w http.ResponseWriter, r *http.Request) {
+	threadID := chi.URLParam(r, "threadId")
+	if threadID == "" {
+		http.Error(w, "missing thread id", http.StatusBadRequest)
+		return
+	}
+
+	if !UseDummy {
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		// Attempt to cancel workflow via agent CLI; ignore error
+		runAgentCLI(ctx, "cancel", threadID, "--force")
+	}
+
+	workflowStatus[threadID] = "ABANDONED"
+	writeJSON(w, map[string]string{"status": "ABANDONED"})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -289,6 +289,9 @@ func main() {
 		r.Get("/workflows", handlers.ListWorkflows)
 		r.Delete("/workflows/{threadId}", handlers.CancelWorkflow)
 	})
+	// Workflow management endpoints
+	r.Get("/api/workflows/{threadId}", handlers.GetWorkflowState)
+	r.Post("/api/workflows/{threadId}/abandon", handlers.AbandonWorkflow)
 	r.Put("/api/meals/{mealId}/steps/{stepId}", handlers.UpdateStepHandler)
 	r.Delete("/api/meals/{mealId}/steps/{stepId}", handlers.DeleteStepHandler)
 	r.Put("/api/meals/{mealId}/steps/reorder", handlers.ReorderStepsHandler)

--- a/backend/models/workflow.go
+++ b/backend/models/workflow.go
@@ -1,0 +1,12 @@
+package models
+
+// WorkflowState represents the workflow status returned to clients
+// additional fields may be added as needed
+// e.g. meal plan or other state in raw JSON
+
+type WorkflowState struct {
+	ThreadID     string `json:"threadId"`
+	WorkflowType string `json:"workflow_type,omitempty"`
+	CurrentStep  string `json:"current_step,omitempty"`
+	Status       string `json:"status,omitempty"`
+}

--- a/frontend/src/AgentPage.test.tsx
+++ b/frontend/src/AgentPage.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import AgentPage from './AgentPage';
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AgentPage from "./AgentPage";
 
 beforeEach(() => {
   (global.fetch as jest.Mock) = jest.fn();
@@ -9,177 +9,342 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks();
+  localStorage.clear();
 });
 
-test('copies meal plan to clipboard', async () => {
+test("auto resumes from localStorage", async () => {
+  localStorage.setItem("sessionId", "abc");
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({
-      threadId: '123',
-      currentStep: 'started',
-      message: 'hi',
-      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
-    })
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        threadId: "abc",
+        workflow_type: "meal_planning",
+        current_step: "planning",
+        message: "hi",
+        raw: { meal_plan: { days: [] } },
+      }),
+  });
+
+  render(<AgentPage />);
+
+  await waitFor(() =>
+    expect(screen.getByTestId("session-id")).toHaveTextContent("abc"),
+  );
+  expect(screen.queryByTestId("start-session")).not.toBeInTheDocument();
+});
+
+test("clears completed session from storage", async () => {
+  localStorage.setItem("sessionId", "done");
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        threadId: "done",
+        workflow_type: "meal_planning",
+        current_step: "complete",
+      }),
+  });
+
+  render(<AgentPage />);
+
+  await waitFor(() =>
+    expect(screen.getByTestId("start-session")).toBeInTheDocument(),
+  );
+  expect(localStorage.getItem("sessionId")).toBeNull();
+});
+
+test("copies meal plan to clipboard", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () =>
+      Promise.resolve({
+        threadId: "123",
+        currentStep: "started",
+        message: "hi",
+        initialState: {
+          meal_plan: {
+            days: [
+              {
+                dayIndex: 0,
+                mealType: "breakfast",
+                meal: { id: 1, name: "Eggs", effort: 1 },
+              },
+            ],
+          },
+        },
+      }),
   });
 
   const write = jest.fn();
   Object.assign(navigator, { clipboard: { write, writeText: write } });
   // Mock ClipboardItem constructor
-  (global as any).ClipboardItem = jest.fn().mockImplementation(data => ({ data }));
+  (global as any).ClipboardItem = jest
+    .fn()
+    .mockImplementation((data) => ({ data }));
 
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
+  fireEvent.click(screen.getByTestId("start-session"));
 
-  await waitFor(() => expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.getByTestId("meal-plan-table")).toBeInTheDocument(),
+  );
 
-  fireEvent.click(screen.getByTestId('copy-meal-plan'));
+  fireEvent.click(screen.getByTestId("copy-meal-plan"));
   expect(write).toHaveBeenCalled();
 });
 
-test('copies shopping list to clipboard', async () => {
+test("copies shopping list to clipboard", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({
-      threadId: '123',
-      currentStep: 'started',
-      message: 'hi',
-      raw: { meal_plan: { days: [] }, shopping_list_formatted: '- eggs\n' }
-    })
+    json: () =>
+      Promise.resolve({
+        threadId: "123",
+        currentStep: "started",
+        message: "hi",
+        raw: { meal_plan: { days: [] }, shopping_list_formatted: "- eggs\n" },
+      }),
   });
 
   const writeText = jest.fn();
   Object.assign(navigator, { clipboard: { writeText } });
 
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
+  fireEvent.click(screen.getByTestId("start-session"));
 
-  await waitFor(() => expect(screen.getByTestId('copy-shopping-list')).toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.getByTestId("copy-shopping-list")).toBeInTheDocument(),
+  );
 
-  fireEvent.click(screen.getByTestId('copy-shopping-list'));
-  expect(writeText).toHaveBeenCalledWith('- eggs\n');
+  fireEvent.click(screen.getByTestId("copy-shopping-list"));
+  expect(writeText).toHaveBeenCalledWith("- eggs\n");
 });
 
-test('starts a new session', async () => {
+test("starts a new session", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({
-      threadId: '123',
-      currentStep: 'started',
-      message: 'hi',
-      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
-    })
+    json: () =>
+      Promise.resolve({
+        threadId: "123",
+        currentStep: "started",
+        message: "hi",
+        initialState: {
+          meal_plan: {
+            days: [
+              {
+                dayIndex: 0,
+                mealType: "breakfast",
+                meal: { id: 1, name: "Eggs", effort: 1 },
+              },
+            ],
+          },
+        },
+      }),
   });
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
+  fireEvent.click(screen.getByTestId("start-session"));
   await waitFor(() => {
-    expect(global.fetch).toHaveBeenCalledWith('/api/agent/start', expect.any(Object));
-    expect(screen.getByTestId('session-id')).toHaveTextContent('123');
-    expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/agent/start",
+      expect.any(Object),
+    );
+    expect(screen.getByTestId("session-id")).toHaveTextContent("123");
+    expect(screen.getByTestId("meal-plan-table")).toBeInTheDocument();
   });
 });
 
-test('sends a message in an existing session', async () => {
+test("sends a message in an existing session", async () => {
   // start session response
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({ threadId: '123', currentStep: 'started' })
+    json: () => Promise.resolve({ threadId: "123", currentStep: "started" }),
   });
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
-  await waitFor(() => expect(screen.getByTestId('message-input')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId("start-session"));
+  await waitFor(() =>
+    expect(screen.getByTestId("message-input")).toBeInTheDocument(),
+  );
 
   // feedback response
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({}),
+  });
   // resume response
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok', raw: { meal_plan: { days: [] } } }) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () =>
+      Promise.resolve({ message: "ok", raw: { meal_plan: { days: [] } } }),
+  });
 
-  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'hello' } });
-  fireEvent.click(screen.getByTestId('send-button'));
+  fireEvent.change(screen.getByTestId("message-input"), {
+    target: { value: "hello" },
+  });
+  fireEvent.click(screen.getByTestId("send-button"));
 
   await waitFor(() => {
-    const feedbackCall = (global.fetch as jest.Mock).mock.calls.find(c => c[0] === '/api/agent/feedback');
-    const resumeCall = (global.fetch as jest.Mock).mock.calls.find(c => c[0] === '/api/agent/resume');
+    const feedbackCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[0] === "/api/agent/feedback",
+    );
+    const resumeCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[0] === "/api/agent/resume",
+    );
     expect(feedbackCall).toBeTruthy();
     expect(resumeCall).toBeTruthy();
     if (feedbackCall) {
-      expect(JSON.parse(feedbackCall[1].body).threadId).toBe('123');
+      expect(JSON.parse(feedbackCall[1].body).threadId).toBe("123");
     }
     if (resumeCall) {
-      expect(JSON.parse(resumeCall[1].body).threadId).toBe('123');
+      expect(JSON.parse(resumeCall[1].body).threadId).toBe("123");
     }
-    expect(screen.getByText('ok')).toBeInTheDocument();
+    expect(screen.getByText("ok")).toBeInTheDocument();
   });
 });
 
-test('pressing Enter sends the message', async () => {
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ threadId: '123', currentStep: 'started' }) });
-  render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
-  await waitFor(() => expect(screen.getByTestId('message-input')).toBeInTheDocument());
-
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ message: 'ok', raw: { meal_plan: { days: [] } } }) });
-
-  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'hello' } });
-  fireEvent.keyPress(screen.getByTestId('message-input'), { key: 'Enter', code: 'Enter', charCode: 13 });
-
-  await waitFor(() => expect(screen.getByText('ok')).toBeInTheDocument());
-});
-
-test('highlights changed meal plan entries', async () => {
+test("pressing Enter sends the message", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
-    json: () => Promise.resolve({
-      threadId: '123',
-      currentStep: 'started',
-      initialState: { meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'Eggs', effort: 1 } } ] } }
-    })
+    json: () => Promise.resolve({ threadId: "123", currentStep: "started" }),
+  });
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId("start-session"));
+  await waitFor(() =>
+    expect(screen.getByTestId("message-input")).toBeInTheDocument(),
+  );
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({}),
+  });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () =>
+      Promise.resolve({ message: "ok", raw: { meal_plan: { days: [] } } }),
+  });
+
+  fireEvent.change(screen.getByTestId("message-input"), {
+    target: { value: "hello" },
+  });
+  fireEvent.keyPress(screen.getByTestId("message-input"), {
+    key: "Enter",
+    code: "Enter",
+    charCode: 13,
+  });
+
+  await waitFor(() => expect(screen.getByText("ok")).toBeInTheDocument());
+});
+
+test("highlights changed meal plan entries", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () =>
+      Promise.resolve({
+        threadId: "123",
+        currentStep: "started",
+        initialState: {
+          meal_plan: {
+            days: [
+              {
+                dayIndex: 0,
+                mealType: "breakfast",
+                meal: { id: 1, name: "Eggs", effort: 1 },
+              },
+            ],
+          },
+        },
+      }),
   });
 
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
+  fireEvent.click(screen.getByTestId("start-session"));
 
-  await waitFor(() => expect(screen.getByTestId('meal-plan-table')).toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.getByTestId("meal-plan-table")).toBeInTheDocument(),
+  );
 
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
-  (global.fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ 
-    message: 'ok', 
-    meal_plan: { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 2, name: 'Pancakes', effort: 1 } } ] }
-  }) });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({}),
+  });
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () =>
+      Promise.resolve({
+        message: "ok",
+        meal_plan: {
+          days: [
+            {
+              dayIndex: 0,
+              mealType: "breakfast",
+              meal: { id: 2, name: "Pancakes", effort: 1 },
+            },
+          ],
+        },
+      }),
+  });
 
-  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'change' } });
-  fireEvent.click(screen.getByTestId('send-button'));
+  fireEvent.change(screen.getByTestId("message-input"), {
+    target: { value: "change" },
+  });
+  fireEvent.click(screen.getByTestId("send-button"));
 
   await waitFor(() => {
-    const mealElement = screen.getByTestId('meal-0-breakfast');
+    const mealElement = screen.getByTestId("meal-0-breakfast");
     // Check that the meal name span has the highlight style
-    const mealNameSpan = mealElement.querySelector('span');
-    expect(mealNameSpan).toHaveStyle({ backgroundColor: '#81c784' });
-  }); 
+    const mealNameSpan = mealElement.querySelector("span");
+    expect(mealNameSpan).toHaveStyle({ backgroundColor: "#81c784" });
+  });
 });
 
-test('shows typing indicator when agent is working', async () => {
+test("shows typing indicator when agent is working", async () => {
   let resolvePromise: (value: any) => void;
-  const promise = new Promise(resolve => {
+  const promise = new Promise((resolve) => {
     resolvePromise = resolve;
   });
-  
+
   (global.fetch as jest.Mock).mockReturnValueOnce({
-    json: () => promise
+    json: () => promise,
   });
 
   render(<AgentPage />);
-  fireEvent.click(screen.getByTestId('start-session'));
+  fireEvent.click(screen.getByTestId("start-session"));
 
   // Check that typing indicator appears when working
   await waitFor(() => {
-    expect(screen.getByTestId('typing-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId("typing-indicator")).toBeInTheDocument();
   });
 
   // Resolve the promise to complete the request
   resolvePromise!({
-    threadId: '123',
-    currentStep: 'started',
-    message: 'Ready'
+    threadId: "123",
+    currentStep: "started",
+    message: "Ready",
   });
 
   // Wait for typing indicator to disappear
   await waitFor(() => {
-    expect(screen.queryByTestId('typing-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId("typing-indicator")).not.toBeInTheDocument();
   });
+});
+
+test("startNewSession abandons existing workflow", async () => {
+  localStorage.setItem("sessionId", "old");
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ threadId: "old", current_step: "planning" }),
+    }) // initial resume check
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ status: "ABANDONED" }),
+    }) // abandon
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ threadId: "new", currentStep: "started" }),
+    });
+
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId("start-session"));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+  expect(global.fetch).toHaveBeenNthCalledWith(1, "/api/workflows/old");
+  expect(global.fetch).toHaveBeenNthCalledWith(
+    2,
+    "/api/workflows/old/abandon",
+    expect.objectContaining({ method: "POST" }),
+  );
+  expect(global.fetch).toHaveBeenNthCalledWith(
+    3,
+    "/api/agent/start",
+    expect.any(Object),
+  );
+  expect(localStorage.getItem("sessionId")).toBe("new");
 });

--- a/frontend/src/AgentPage.tsx
+++ b/frontend/src/AgentPage.tsx
@@ -1,45 +1,68 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { Box, Button, TextField, Typography, Paper, Avatar, IconButton } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
-import MealPlanDisplay, { WeeklyMealPlan } from './components/MealPlanDisplay';
-import TypingIndicator from './components/TypingIndicator';
+import React, { useState, useRef, useEffect } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Paper,
+  Avatar,
+  IconButton,
+} from "@mui/material";
+import SendIcon from "@mui/icons-material/Send";
+import MealPlanDisplay, { WeeklyMealPlan } from "./components/MealPlanDisplay";
+import TypingIndicator from "./components/TypingIndicator";
+import useSession from "./hooks/useSession";
 
 // Utility to format a WeeklyMealPlan for clipboard copying
-const WEEK_DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+const WEEK_DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 function formatMealPlan(plan: WeeklyMealPlan): { html: string; text: string } {
   let html = '<table style="border-collapse: collapse; width: 100%;">';
-  html += '<thead><tr>' +
-          '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Day</th>' +
-          '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Meals</th>' +
-          '</tr></thead><tbody>';
+  html +=
+    "<thead><tr>" +
+    '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Day</th>' +
+    '<th style="border:1px solid #ddd;padding:8px;text-align:left;">Meals</th>' +
+    "</tr></thead><tbody>";
 
-  let text = 'Day | Meals\n';
-  text += '----|------\n';
+  let text = "Day | Meals\n";
+  text += "----|------\n";
 
   WEEK_DAYS.forEach((day, idx) => {
-    const entries = plan.days.filter(d => d.dayIndex === idx);
+    const entries = plan.days.filter((d) => d.dayIndex === idx);
     if (entries.length === 0) return;
 
-    const mealsHtml = entries.map(e => {
-      const meal = e.meal;
-      return `<strong>${e.mealType.charAt(0).toUpperCase()+e.mealType.slice(1)}</strong>: ${meal.name} (${meal.effort})`;
-    }).join('<br>');
-    html += `<tr><td style="border:1px solid #ddd;padding:8px;">${day}</td>` +
-            `<td style="border:1px solid #ddd;padding:8px;">${mealsHtml}</td></tr>`;
+    const mealsHtml = entries
+      .map((e) => {
+        const meal = e.meal;
+        return `<strong>${e.mealType.charAt(0).toUpperCase() + e.mealType.slice(1)}</strong>: ${meal.name} (${meal.effort})`;
+      })
+      .join("<br>");
+    html +=
+      `<tr><td style="border:1px solid #ddd;padding:8px;">${day}</td>` +
+      `<td style="border:1px solid #ddd;padding:8px;">${mealsHtml}</td></tr>`;
 
-    const mealsText = entries.map(e => {
-      const meal = e.meal;
-      return `${e.mealType}: ${meal.name} (${meal.effort})`;
-    }).join('; ');
+    const mealsText = entries
+      .map((e) => {
+        const meal = e.meal;
+        return `${e.mealType}: ${meal.name} (${meal.effort})`;
+      })
+      .join("; ");
     text += `${day} | ${mealsText}\n`;
   });
 
-  html += '</tbody></table>';
+  html += "</tbody></table>";
   return { html, text };
 }
 
 interface ChatMessage {
-  sender: 'user' | 'agent';
+  sender: "user" | "agent";
   text: string;
 }
 
@@ -50,7 +73,7 @@ interface SessionInfo {
 
 const AgentPage: React.FC = () => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [isWorking, setIsWorking] = useState(false);
   const [mealPlan, setMealPlan] = useState<WeeklyMealPlan | null>(null);
@@ -66,22 +89,24 @@ const AgentPage: React.FC = () => {
   }, [messages]);
 
   const applyHighlights = (newPlan: WeeklyMealPlan) => {
-    setHighlights(prev => {
+    setHighlights((prev) => {
       const changed = new Set<string>();
       if (mealPlan) {
-        newPlan.days.forEach(d => {
-          const prevEntry = mealPlan.days.find(p => p.dayIndex === d.dayIndex && p.mealType === d.mealType);
+        newPlan.days.forEach((d) => {
+          const prevEntry = mealPlan.days.find(
+            (p) => p.dayIndex === d.dayIndex && p.mealType === d.mealType,
+          );
           if (!prevEntry || prevEntry.meal.id !== d.meal.id) {
             changed.add(`${d.dayIndex}-${d.mealType}`);
           }
         });
       }
-      
+
       if (changed.size > 0) {
         setTimeout(() => {
-          setHighlights(h => {
+          setHighlights((h) => {
             const copy = new Set(h);
-            changed.forEach(k => copy.delete(k));
+            changed.forEach((k) => copy.delete(k));
             return copy;
           });
         }, 5000);
@@ -94,64 +119,110 @@ const AgentPage: React.FC = () => {
   const startSession = async () => {
     setIsWorking(true);
     try {
-      const res = await fetch('/api/agent/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participants: ['user'], workflowType: 'meal_planning' })
+      const res = await fetch("/api/agent/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          participants: ["user"],
+          workflowType: "meal_planning",
+        }),
       });
       const data = await res.json();
       setSession({ threadId: data.threadId, currentStep: data.currentStep });
-      
+      localStorage.setItem("sessionId", data.threadId);
+
       // Extract meal plan from various possible locations in response
-      const plan = data.initialState?.meal_plan || data.raw?.meal_plan || data.meal_plan;
+      const plan =
+        data.initialState?.meal_plan || data.raw?.meal_plan || data.meal_plan;
       if (plan) {
-        console.log('Setting meal plan from session start:', plan);
+        console.log("Setting meal plan from session start:", plan);
         setMealPlan(plan);
       }
-      
-      if (data.raw?.shopping_list_formatted || data.initialState?.shopping_list) {
-        setShoppingList(data.raw?.shopping_list_formatted || data.initialState?.shopping_list);
+
+      if (
+        data.raw?.shopping_list_formatted ||
+        data.initialState?.shopping_list
+      ) {
+        setShoppingList(
+          data.raw?.shopping_list_formatted || data.initialState?.shopping_list,
+        );
       }
-      if (data.message) setMessages([{ sender: 'agent', text: data.message }]);
+      if (data.message) setMessages([{ sender: "agent", text: data.message }]);
     } catch (err) {
-      console.error('Failed to start session', err);
+      console.error("Failed to start session", err);
     } finally {
       setIsWorking(false);
     }
   };
 
+  const { isResuming, resumeData, startNewSession } = useSession(startSession);
+
+  useEffect(() => {
+    if (resumeData) {
+      setSession({
+        threadId: resumeData.threadId,
+        currentStep: resumeData.current_step,
+      });
+      const plan =
+        resumeData.initialState?.meal_plan ||
+        resumeData.raw?.meal_plan ||
+        resumeData.meal_plan;
+      if (plan) {
+        setMealPlan(plan);
+      }
+      const list =
+        resumeData.raw?.shopping_list_formatted ||
+        resumeData.initialState?.shopping_list;
+      if (list) setShoppingList(list);
+      if (resumeData.message)
+        setMessages([{ sender: "agent", text: resumeData.message }]);
+    }
+  }, [resumeData]);
+
   const sendMessage = async () => {
     if (!session || !input.trim()) return;
-    const userMsg: ChatMessage = { sender: 'user', text: input };
-    setMessages(prev => [...prev, userMsg]);
-    setInput('');
+    const userMsg: ChatMessage = { sender: "user", text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
     setIsWorking(true);
     try {
-      await fetch('/api/agent/feedback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ threadId: session.threadId, message: userMsg.text, from: 'user' })
+      await fetch("/api/agent/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: session.threadId,
+          message: userMsg.text,
+          from: "user",
+        }),
       });
-      const res = await fetch('/api/agent/resume', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ threadId: session.threadId, interactive: false })
+      const res = await fetch("/api/agent/resume", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: session.threadId,
+          interactive: false,
+        }),
       });
       const data = await res.json();
-      if (data.message) setMessages(prev => [...prev, { sender: 'agent', text: data.message }]);
-      
+      if (data.message)
+        setMessages((prev) => [
+          ...prev,
+          { sender: "agent", text: data.message },
+        ]);
+
       // Check for meal plan in both top level and raw
       const newMealPlan = data.meal_plan || data.raw?.meal_plan;
       if (newMealPlan) {
-        console.log('Applying highlights for new meal plan:', newMealPlan);
+        console.log("Applying highlights for new meal plan:", newMealPlan);
         applyHighlights(newMealPlan);
       }
-      
+
       // Check for shopping list in both locations
-      const newShoppingList = data.shopping_list_formatted || data.raw?.shopping_list_formatted;
+      const newShoppingList =
+        data.shopping_list_formatted || data.raw?.shopping_list_formatted;
       if (newShoppingList) setShoppingList(newShoppingList);
     } catch (err) {
-      console.error('Failed to send message', err);
+      console.error("Failed to send message", err);
     } finally {
       setIsWorking(false);
     }
@@ -162,8 +233,8 @@ const AgentPage: React.FC = () => {
     const { html, text } = formatMealPlan(mealPlan);
     try {
       const item = new ClipboardItem({
-        'text/html': new Blob([html], { type: 'text/html' }),
-        'text/plain': new Blob([text], { type: 'text/plain' })
+        "text/html": new Blob([html], { type: "text/html" }),
+        "text/plain": new Blob([text], { type: "text/plain" }),
       });
       navigator.clipboard.write([item]);
     } catch (e) {
@@ -177,26 +248,65 @@ const AgentPage: React.FC = () => {
   };
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       sendMessage();
     }
   };
 
   return (
-    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Button onClick={startSession} variant="contained" data-testid="start-session">Start New Session</Button>
-      {session && (
-        <Typography data-testid="session-id">Session: {session.threadId}</Typography>
+    <Box sx={{ p: 2, display: "flex", flexDirection: "column", gap: 2 }}>
+      {!session && (
+        <Button
+          size="small"
+          variant="contained"
+          onClick={startNewSession}
+          data-testid="start-session"
+        >
+          Start&nbsp;New&nbsp;Session
+        </Button>
       )}
-      <Box ref={chatRef} data-testid="chat-history" sx={{ flexGrow: 1, overflowY: 'auto', maxHeight: 300, display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
+      {session && (
+        <Typography data-testid="session-id">
+          Session: {session.threadId}
+        </Typography>
+      )}
+      <Box
+        ref={chatRef}
+        data-testid="chat-history"
+        sx={{
+          flexGrow: 1,
+          overflowY: "auto",
+          maxHeight: 300,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          mt: 1,
+        }}
+      >
         {messages.map((m, i) => (
-          <Box key={i} sx={{ display: 'flex', justifyContent: m.sender === 'user' ? 'flex-end' : 'flex-start' }}>
-            <Paper sx={{ p: 1, maxWidth: '70%', backgroundColor: m.sender === 'user' ? '#eef4ea' : '#fff' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {m.sender === 'agent' && <Avatar sx={{ width: 24, height: 24 }}>A</Avatar>}
+          <Box
+            key={i}
+            sx={{
+              display: "flex",
+              justifyContent: m.sender === "user" ? "flex-end" : "flex-start",
+            }}
+          >
+            <Paper
+              sx={{
+                p: 1,
+                maxWidth: "70%",
+                backgroundColor: m.sender === "user" ? "#eef4ea" : "#fff",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                {m.sender === "agent" && (
+                  <Avatar sx={{ width: 24, height: 24 }}>A</Avatar>
+                )}
                 <Typography variant="body2">{m.text}</Typography>
-                {m.sender === 'user' && <Avatar sx={{ width: 24, height: 24 }}>U</Avatar>}
+                {m.sender === "user" && (
+                  <Avatar sx={{ width: 24, height: 24 }}>U</Avatar>
+                )}
               </Box>
             </Paper>
           </Box>
@@ -206,25 +316,44 @@ const AgentPage: React.FC = () => {
       {mealPlan && (
         <>
           <MealPlanDisplay plan={mealPlan} highlights={highlights} />
-          <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
-            <Button variant="outlined" onClick={copyMealPlan} data-testid="copy-meal-plan">Copy Meal Plan</Button>
-            {shoppingList && <Button variant="outlined" onClick={copyShoppingList} data-testid="copy-shopping-list">Copy Shopping List</Button>}
+          <Box sx={{ mt: 1, display: "flex", gap: 1 }}>
+            <Button
+              variant="outlined"
+              onClick={copyMealPlan}
+              data-testid="copy-meal-plan"
+            >
+              Copy Meal Plan
+            </Button>
+            {shoppingList && (
+              <Button
+                variant="outlined"
+                onClick={copyShoppingList}
+                data-testid="copy-shopping-list"
+              >
+                Copy Shopping List
+              </Button>
+            )}
           </Box>
         </>
       )}
       {session && (
-        <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}>
           <TextField
             fullWidth
             multiline
             minRows={1}
             maxRows={4}
             value={input}
-            onChange={e => setInput(e.target.value)}
+            onChange={(e) => setInput(e.target.value)}
             onKeyPress={handleKeyPress}
-            inputProps={{ 'data-testid': 'message-input' }}
+            inputProps={{ "data-testid": "message-input" }}
           />
-          <IconButton color="primary" onClick={sendMessage} disabled={!input.trim()} data-testid="send-button">
+          <IconButton
+            color="primary"
+            onClick={sendMessage}
+            disabled={!input.trim()}
+            data-testid="send-button"
+          >
             <SendIcon />
           </IconButton>
         </Box>

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+export interface WorkflowState {
+  threadId: string;
+  workflow_type: string;
+  current_step: string;
+  status?: string;
+  [key: string]: any;
+}
+
+export default function useSession(startSession: () => Promise<void>) {
+  const [isResuming, setIsResuming] = useState(false);
+  const [resumeData, setResumeData] = useState<WorkflowState | undefined>();
+
+  useEffect(() => {
+    const id = localStorage.getItem("sessionId");
+    if (!id) return;
+    setIsResuming(true);
+    fetch(`/api/workflows/${id}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((wf: WorkflowState) => {
+        if (
+          wf.current_step &&
+          wf.current_step.toLowerCase() !== "complete" &&
+          wf.status !== "ABANDONED"
+        ) {
+          setResumeData(wf);
+        } else {
+          localStorage.removeItem("sessionId");
+        }
+      })
+      .catch(() => {
+        localStorage.removeItem("sessionId");
+      })
+      .finally(() => setIsResuming(false));
+  }, []);
+
+  const startNewSession = async () => {
+    const existing = localStorage.getItem("sessionId");
+    if (existing) {
+      try {
+        await fetch(`/api/workflows/${existing}/abandon`, { method: "POST" });
+      } catch {
+        // ignore
+      }
+      localStorage.removeItem("sessionId");
+    }
+    await startSession();
+  };
+
+  return { isResuming, resumeData, startNewSession };
+}


### PR DESCRIPTION
## Summary
- add `useSession` hook for workflow resume and abandon handling
- modify `AgentPage` to use `useSession`, persist session ID and hide button
- extend AgentPage tests for resume and abandon cases
- support workflow state and abandon endpoints in backend

## Testing
- `yarn test:frontend`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68582428fee083249239e8bcf399c34e