### PR TITLE
Add session auto-resume hook and backend endpoints

### DIFF
--- a/backend/handlers/agent.go
+++ b/backend/handlers/agent.go
@@ -82,6 +82,12 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	workflowStore[resp.ThreadID] = &models.WorkflowState{
+		ThreadID:     resp.ThreadID,
+		WorkflowType: req.WorkflowType,
+		CurrentStep:  resp.CurrentStep,
+		Status:       models.WorkflowStatusActive,
+	}
 	writeJSON(w, resp)
 }
 
@@ -149,6 +155,9 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if wf, ok := workflowStore[req.ThreadID]; ok {
+		wf.CurrentStep = resp.CurrentStep
 	}
 	writeJSON(w, resp)
 }

--- a/backend/handlers/workflows.go
+++ b/backend/handlers/workflows.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/http"
+
+	"mealplanner/models"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// in-memory store for demo purposes
+var workflowStore = map[string]*models.WorkflowState{}
+
+// GetWorkflow handles GET /api/workflows/{threadId}
+func GetWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "threadId")
+	wf, ok := workflowStore[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, wf)
+}
+
+// AbandonWorkflow handles POST /api/workflows/{threadId}/abandon
+func AbandonWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "threadId")
+	if wf, ok := workflowStore[id]; ok {
+		wf.Status = models.WorkflowStatusAbandoned
+	}
+	writeJSON(w, map[string]string{"status": models.WorkflowStatusAbandoned})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -289,6 +289,10 @@ func main() {
 		r.Get("/workflows", handlers.ListWorkflows)
 		r.Delete("/workflows/{threadId}", handlers.CancelWorkflow)
 	})
+	r.Route("/api/workflows", func(r chi.Router) {
+		r.Get("/{threadId}", handlers.GetWorkflow)
+		r.Post("/{threadId}/abandon", handlers.AbandonWorkflow)
+	})
 	r.Put("/api/meals/{mealId}/steps/{stepId}", handlers.UpdateStepHandler)
 	r.Delete("/api/meals/{mealId}/steps/{stepId}", handlers.DeleteStepHandler)
 	r.Put("/api/meals/{mealId}/steps/reorder", handlers.ReorderStepsHandler)

--- a/backend/migrations/007_add_workflow_status.down.sql
+++ b/backend/migrations/007_add_workflow_status.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workflow_checkpoints DROP COLUMN IF EXISTS status;

--- a/backend/migrations/007_add_workflow_status.up.sql
+++ b/backend/migrations/007_add_workflow_status.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workflow_checkpoints ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'ACTIVE';

--- a/backend/models/workflow.go
+++ b/backend/models/workflow.go
@@ -1,0 +1,14 @@
+package models
+
+// WorkflowStatus indicates overall workflow lifecycle state
+const (
+	WorkflowStatusActive    = "ACTIVE"
+	WorkflowStatusAbandoned = "ABANDONED"
+)
+
+type WorkflowState struct {
+	ThreadID     string `json:"threadId"`
+	WorkflowType string `json:"workflow_type"`
+	CurrentStep  string `json:"current_step"`
+	Status       string `json:"status"`
+}

--- a/docs/SessionAutoResume.md
+++ b/docs/SessionAutoResume.md
@@ -1,0 +1,127 @@
+---
+description: Front-end auto-resume & new-session flow
+---
+# Session Auto-Resume & New-Session Flow
+
+This document details the implementation plan for automatically resuming an incomplete workflow when the frontend loads and gracefully starting a new session. It includes file paths, data schemas, UI tweaks, and API requirements.
+
+## 1. Definitions
+
+| Term | Meaning |
+|------|---------|
+| **Session** | A single instance of a workflow identified by `threadId` (a.k.a. `sessionId` on the client). |
+| **Incomplete Workflow** | Any workflow whose `current_step` enum value is **not** `COMPLETE`. |
+| **Abandoned Workflow** | A workflow the user actively ends without reaching `COMPLETE`; its final status is `ABANDONED`. |
+
+## 2. Data Contract
+
+### 2.1 LocalStorage
+
+```text
+key: "sessionId"
+value: string  // threadId returned by backend when a session is created
+```
+
+### 2.2 Backend JSON (simplified)
+
+```ts
+// GET /api/workflows/{threadId}
+interface WorkflowState {
+  threadId: string;
+  workflow_type: WorkflowType;        // "meal_planning" | "recipe_management" | ...
+  current_step: string;               // Enum per type
+  /* additional fields per workflow schema */
+}
+```
+
+```ts
+// POST /api/workflows/{threadId}/abandon
+Body: {}
+Response 200 OK: { status: "ABANDONED" }
+```
+
+> NOTE: `ABANDONED` is **not** a step; it is a *terminal status* we set on the backend while leaving `current_step` unchanged.
+
+## 3. Front-End Changes
+
+### 3.1 New Hook: `frontend/src/hooks/useSession.ts`
+
+* Encapsulates session detection, resumption, and abandonment logic.
+* Exposes:
+  * `isResuming: boolean` – true while fetching resume data.
+  * `resumeData?: WorkflowState` – populated on successful resume.
+  * `startNewSession(): Promise<void>` – wraps existing start-session flow and handles abandonment.
+
+### 3.2 Modify `frontend/src/AgentPage.tsx`
+
+* Import `useSession`.
+* On mount, call the hook; if `resumeData` exists, hydrate UI components (existing props already expect fetched data).
+* Replace current button:
+
+```tsx
+<Button
+  size="small"                // previously default (large)
+  variant="contained"
+  onClick={startNewSession}
+  data-testid="start-session"
+>
+  Start\u00a0New\u00a0Session
+</Button>
+```
+
+### 3.3 Unit Tests
+
+* `AgentPage.test.tsx` – add cases for:
+  * LocalStorage with incomplete workflow \u2192 auto-resume hides button.
+  * Completed workflow in storage \u2192 storage cleared, button visible.
+  * `startNewSession()` sends abandon request when needed.
+
+## 4. Backend Changes
+
+* Add **POST** `/api/workflows/{threadId}/abandon` route (if missing).
+  * Marks record `status = "ABANDONED"` (new column if necessary).
+* Ensure `GET /api/workflows/{threadId}` returns `current_step` so client can determine completion.
+
+## 5. File-by-File Worklist
+
+| File | Action |
+|------|--------|
+| `frontend/src/hooks/useSession.ts` | **NEW** – hook implementation. |
+| `frontend/src/AgentPage.tsx` | Import hook, consume `resumeData`, shrink button. |
+| `frontend/src/AgentPage.test.tsx` | Add tests. |
+| `backend/routes/workflows.go` (or equivalent) | Add abandon endpoint handler. |
+| `backend/models/workflow.go` | Add `status` field/enum with `ABANDONED`. |
+| Migrations | Create column `status VARCHAR DEFAULT 'ACTIVE'`. |
+
+## 6. Implementation Steps
+
+1. **Schema**: Update Go model and migration to include `status`.
+2. **API**: Implement abandon handler to set `status = 'ABANDONED'`.
+3. **Hook**: Create `useSession` with logic:
+   ```ts
+   useEffect(() => {
+     const id = localStorage.getItem('sessionId');
+     if (!id) return;
+     fetch(`/api/workflows/${id}`)
+       .then(r => r.json())
+       .then(wf => {
+         if (wf.current_step !== 'complete') {
+           setResumeData(wf);
+         } else {
+           localStorage.removeItem('sessionId');
+         }
+       });
+   }, []);
+   ```
+4. **AgentPage**: Use hook; if `resumeData`, bypass new-session flow.
+5. **Button**: Change size to `small`.
+6. **Testing**: Extend existing RTL tests.
+7. **Docs**: Keep this file updated when implementation evolves.
+
+## 7. Acceptance Criteria
+
+- Landing on the site with `sessionId` of an incomplete workflow automatically resumes and hides the big button.
+- Landing with no session or a completed one shows the small button.
+- Starting a new session abandons any existing one.
+- All new tests pass; existing tests remain green.
+- CI, lint, and Go unit tests pass.

--- a/frontend/src/AgentPage.test.tsx
+++ b/frontend/src/AgentPage.test.tsx
@@ -9,6 +9,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks();
+  localStorage.clear();
 });
 
 test('copies meal plan to clipboard', async () => {
@@ -181,5 +182,43 @@ test('shows typing indicator when agent is working', async () => {
   // Wait for typing indicator to disappear
   await waitFor(() => {
     expect(screen.queryByTestId('typing-indicator')).not.toBeInTheDocument();
+  });
+});
+
+test('auto resumes session from localStorage', async () => {
+  localStorage.setItem('sessionId', 'abc');
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ threadId: 'abc', workflow_type: 'meal_planning', current_step: 'started', meal_plan: { days: [] } })
+  });
+  render(<AgentPage />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/workflows/abc'));
+  await waitFor(() => expect(screen.queryByTestId('start-session')).not.toBeInTheDocument());
+  localStorage.removeItem('sessionId');
+});
+
+test('clears completed session from localStorage', async () => {
+  localStorage.setItem('sessionId', 'def');
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ threadId: 'def', workflow_type: 'meal_planning', current_step: 'complete' })
+  });
+  render(<AgentPage />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  expect(localStorage.getItem('sessionId')).toBeNull();
+  expect(screen.getByTestId('start-session')).toBeInTheDocument();
+});
+
+test('abandon called when starting new session', async () => {
+  localStorage.setItem('sessionId', 'old');
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ threadId: 'old', workflow_type: 'meal_planning', current_step: 'started' }) })
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ status: 'ABANDONED' }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ threadId: 'new', currentStep: 'started' }) });
+  render(<AgentPage />);
+  fireEvent.click(screen.getByTestId('start-session'));
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith('/api/workflows/old/abandon', expect.any(Object));
+    expect(global.fetch).toHaveBeenCalledWith('/api/agent/start', expect.any(Object));
   });
 });

--- a/frontend/src/AgentPage.tsx
+++ b/frontend/src/AgentPage.tsx
@@ -3,6 +3,7 @@ import { Box, Button, TextField, Typography, Paper, Avatar, IconButton } from '@
 import SendIcon from '@mui/icons-material/Send';
 import MealPlanDisplay, { WeeklyMealPlan } from './components/MealPlanDisplay';
 import TypingIndicator from './components/TypingIndicator';
+import useSession from './hooks/useSession';
 
 // Utility to format a WeeklyMealPlan for clipboard copying
 const WEEK_DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
@@ -49,6 +50,8 @@ interface SessionInfo {
 }
 
 const AgentPage: React.FC = () => {
+  const { isResuming, resumeData, startNewSession: startNewSessionHook } = useSession();
+
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [session, setSession] = useState<SessionInfo | null>(null);
@@ -64,6 +67,15 @@ const AgentPage: React.FC = () => {
       el.scrollTop = el.scrollHeight;
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (!resumeData) return;
+    setSession({ threadId: resumeData.threadId, currentStep: resumeData.current_step });
+    const plan = (resumeData as any).meal_plan;
+    if (plan) setMealPlan(plan);
+    const list = (resumeData as any).shopping_list_formatted || (resumeData as any).shopping_list;
+    if (list) setShoppingList(list);
+  }, [resumeData]);
 
   const applyHighlights = (newPlan: WeeklyMealPlan) => {
     setHighlights(prev => {
@@ -91,15 +103,10 @@ const AgentPage: React.FC = () => {
     setMealPlan(newPlan);
   };
 
-  const startSession = async () => {
+  const startNewSession = async () => {
     setIsWorking(true);
     try {
-      const res = await fetch('/api/agent/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participants: ['user'], workflowType: 'meal_planning' })
-      });
-      const data = await res.json();
+      const data = await startNewSessionHook();
       setSession({ threadId: data.threadId, currentStep: data.currentStep });
       
       // Extract meal plan from various possible locations in response
@@ -185,7 +192,7 @@ const AgentPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Button onClick={startSession} variant="contained" data-testid="start-session">Start New Session</Button>
+      {!session && <Button size="small" variant="contained" onClick={startNewSession} data-testid="start-session">Start&nbsp;New&nbsp;Session</Button>}
       {session && (
         <Typography data-testid="session-id">Session: {session.threadId}</Typography>
       )}

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface WorkflowState {
+  threadId: string;
+  workflow_type: string;
+  current_step: string;
+  status?: string;
+}
+
+export default function useSession() {
+  const [isResuming, setIsResuming] = useState(false);
+  const [resumeData, setResumeData] = useState<WorkflowState | undefined>();
+
+  useEffect(() => {
+    const id = localStorage.getItem('sessionId');
+    if (!id) return;
+    setIsResuming(true);
+    fetch(`/api/workflows/${id}`)
+      .then(r => {
+        if (!r.ok) throw new Error('failed');
+        return r.json();
+      })
+      .then((wf: WorkflowState) => {
+        if (wf.current_step !== 'complete' && wf.status !== 'ABANDONED') {
+          setResumeData(wf);
+        } else {
+          localStorage.removeItem('sessionId');
+        }
+      })
+      .catch(() => {
+        localStorage.removeItem('sessionId');
+      })
+      .finally(() => setIsResuming(false));
+  }, []);
+
+  const startNewSession = useCallback(async () => {
+    const existing = localStorage.getItem('sessionId');
+    if (existing) {
+      try {
+        await fetch(`/api/workflows/${existing}/abandon`, { method: 'POST' });
+      } catch {
+        // ignore network errors
+      }
+      localStorage.removeItem('sessionId');
+    }
+
+    const res = await fetch('/api/agent/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participants: ['user'], workflowType: 'meal_planning' })
+    });
+    const data = await res.json();
+    localStorage.setItem('sessionId', data.threadId);
+    return data;
+  }, []);
+
+  return { isResuming, resumeData, startNewSession } as const;
+}


### PR DESCRIPTION
## Summary
- document session auto-resume flow
- create useSession hook to resume previous workflow and abandon old sessions
- integrate hook into AgentPage and shrink the new session button
- add frontend tests for resume/abandon logic
- implement minimal workflow handlers and status tracking in the backend
- wire up new `/api/workflows` routes and migration

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68582428fee083249239e8bcf399c34e