### PR TITLE
Add frontend tests and update agent test expectations

### DIFF
--- a/agent/tests/meal-planning.integration.test.ts
+++ b/agent/tests/meal-planning.integration.test.ts
@@ -31,7 +31,7 @@ describe('MealPlanningWorkflow LLM integration and edge cases', () => {
   describe('applyFeedbackWithLLM', () => {
     beforeEach(() => {
       // Mocks for availableMeals and newPlan
-      const availableMeals = [{ id: 2, mealName: 'x', mealType: 'breakfast', relativeEffort: 1, redMeat: false }];
+      const availableMeals = [{ id: 2, name: 'x', mealType: 'breakfast', effort: 1, hasRedMeat: false }];
       const newPlan = { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 2, name: 'x', effort: 1, hasRedMeat: false } } ] };
       workflow.client = { callTool: jest.fn().mockResolvedValue({ content: [{ text: JSON.stringify(availableMeals) }] }) } as any;
       workflow.llm = { invoke: jest.fn().mockResolvedValue(JSON.stringify(newPlan)) } as any;
@@ -40,8 +40,8 @@ describe('MealPlanningWorkflow LLM integration and edge cases', () => {
 
     it('applies feedback and returns new plan', async () => {
       // Setup: plan has Sunday breakfast with id 1, availableMeals has id 2
-      const plan = { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 1, name: 'old', effort: 1, hasRedMeat: false } } ] };
-      const availableMeals = [{ id: 2, mealName: 'x', mealType: 'breakfast', relativeEffort: 1, redMeat: false }];
+      const plan = { days: [ { dayIndex: 6, mealType: 'breakfast', meal: { id: 1, name: 'old', effort: 1, hasRedMeat: false } } ] };
+      const availableMeals = [{ id: 2, name: 'x', mealType: 'breakfast', effort: 1, hasRedMeat: false }];
       workflow.client.callTool.mockResolvedValue({ content: [{ text: JSON.stringify(availableMeals) }] });
       workflow.llm.invoke.mockResolvedValue({ content: JSON.stringify({
         replacements: [
@@ -53,7 +53,7 @@ describe('MealPlanningWorkflow LLM integration and edge cases', () => {
       workflow.extractJsonFromResponse = jest.fn((s: any) => (typeof s === 'string' ? s : JSON.stringify(s)) );
       const res = await workflow.applyFeedbackWithLLM(plan, ['replace Sunday breakfast']);
       // Expect the plan to be updated with meal id 2
-      const expectedPlan = { days: [ { dayIndex: 0, mealType: 'breakfast', meal: { id: 2, name: 'x', effort: 1, hasRedMeat: false } } ] };
+      const expectedPlan = { days: [ { dayIndex: 6, mealType: 'breakfast', meal: { id: 2, name: 'x', effort: 1, hasRedMeat: false } } ] };
       expect(workflow.client.callTool).toHaveBeenCalledWith({ name: 'getMeals', arguments: {} });
       expect(workflow.llm.invoke).toHaveBeenCalled();
       expect(res).toEqual({ mealPlan: expectedPlan, userMessage: 'done' });

--- a/agent/tests/meal-planning.test.ts
+++ b/agent/tests/meal-planning.test.ts
@@ -76,24 +76,24 @@ describe('MealPlanningWorkflow logic', () => {
   describe('transformBackendPlan', () => {
     it('maps backend JSON to WeeklyMealPlan days array including empty slots', () => {
       const backendPlan = {
-        Sunday: { Breakfast: { id: 10, mealName: 'eggs', relativeEffort: 2, redMeat: false } },
-        Monday: { Dinner: { id: 20, mealName: 'steak', relativeEffort: 5, redMeat: true } },
+        Sunday: { Breakfast: { id: 10, name: 'eggs', effort: 2, hasRedMeat: false } },
+        Monday: { Dinner: { id: 20, name: 'steak', effort: 5, hasRedMeat: true } },
       };
       const plan: WeeklyMealPlan = workflow.transformBackendPlan(backendPlan);
-      const sundayBreakfast = plan.days.find(d => d.dayIndex === 0 && d.mealType === 'breakfast');
+      const sundayBreakfast = plan.days.find(d => d.dayIndex === 6 && d.mealType === 'breakfast');
       expect(sundayBreakfast?.meal).toEqual({ id: 10, name: 'eggs', effort: 2, hasRedMeat: false });
-      const mondayDinner = plan.days.find(d => d.dayIndex === 1 && d.mealType === 'dinner');
+      const mondayDinner = plan.days.find(d => d.dayIndex === 0 && d.mealType === 'dinner');
       expect(mondayDinner?.meal).toEqual({ id: 20, name: 'steak', effort: 5, hasRedMeat: true });
       const emptyCount = plan.days.filter(d => d.meal === null).length;
       expect(emptyCount).toBe(21 - 2);
     });
 
     it('creates empty entries for days without data', () => {
-      const backendPlan = { Wednesday: {}, Friday: { Lunch: { id: 5, mealName: 'salad', relativeEffort: 1, redMeat: false } } };
+      const backendPlan = { Wednesday: {}, Friday: { Lunch: { id: 5, name: 'salad', effort: 1, hasRedMeat: false } } };
       const plan: WeeklyMealPlan = workflow.transformBackendPlan(backendPlan);
-      const fridayLunch = plan.days.find(d => d.dayIndex === 5 && d.mealType === 'lunch');
+      const fridayLunch = plan.days.find(d => d.dayIndex === 4 && d.mealType === 'lunch');
       expect(fridayLunch?.meal).toEqual({ id: 5, name: 'salad', effort: 1, hasRedMeat: false });
-      const wednesdayDinner = plan.days.find(d => d.dayIndex === 3 && d.mealType === 'dinner');
+      const wednesdayDinner = plan.days.find(d => d.dayIndex === 2 && d.mealType === 'dinner');
       expect(wednesdayDinner?.meal).toBeNull();
     });
   });

--- a/frontend/src/components/MealPlanDisplay.test.tsx
+++ b/frontend/src/components/MealPlanDisplay.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MealPlanDisplay, { WeeklyMealPlan } from './MealPlanDisplay';
+import '@testing-library/jest-dom';
+
+function buildPlan(): WeeklyMealPlan {
+  const days: WeeklyMealPlan['days'] = [];
+  for (let i = 0; i < 7; i++) {
+    ['breakfast','lunch','dinner'].forEach(mt => {
+      days.push({ dayIndex: i, mealType: mt, meal: null });
+    });
+  }
+  days[0].meal = { id: 1, name: 'Eggs', effort: 1, hasRedMeat: false };
+  days[2*3+2].meal = { id: 2, name: 'Steak', effort: 3, hasRedMeat: true }; // Wednesday dinner
+  return { days };
+}
+
+describe('MealPlanDisplay', () => {
+  test('renders meal names in correct positions', () => {
+    const plan = buildPlan();
+    render(<MealPlanDisplay plan={plan} />);
+    expect(screen.getByText('Eggs')).toBeInTheDocument();
+    expect(screen.getByText('Steak')).toBeInTheDocument();
+  });
+
+  test('shows placeholder for empty meals', () => {
+    const plan = buildPlan();
+    render(<MealPlanDisplay plan={plan} />);
+    const empty = screen.getByTestId('meal-0-lunch');
+    expect(empty).toHaveTextContent('---');
+  });
+
+  test('displays red meat indicator', () => {
+    const plan = buildPlan();
+    render(<MealPlanDisplay plan={plan} />);
+    const steak = screen.getByText('Steak');
+    expect(steak.nextSibling).toHaveTextContent('🥩');
+  });
+
+  test('displays day headers', () => {
+    const plan = buildPlan();
+    render(<MealPlanDisplay plan={plan} />);
+    expect(screen.getByText('Monday')).toBeInTheDocument();
+    expect(screen.getByText('Sunday')).toBeInTheDocument();
+  });
+
+  test('shows effort icons', () => {
+    const plan = buildPlan();
+    render(<MealPlanDisplay plan={plan} />);
+    const eggs = screen.getByText('Eggs');
+    expect(eggs.nextSibling).toHaveTextContent('🔥');
+  });
+});

--- a/frontend/src/components/Toast.test.tsx
+++ b/frontend/src/components/Toast.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { Toast } from './Toast';
+import '@testing-library/jest-dom';
+
+describe('Toast', () => {
+  const theme = createTheme();
+
+  test('renders message when provided', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Toast message="Saved" />
+      </ThemeProvider>
+    );
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  test('renders nothing when message is null', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Toast message={null} />
+      </ThemeProvider>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useSession.test.tsx
+++ b/frontend/src/hooks/useSession.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import useSession from './useSession';
+
+// Helper component for renderHook with React 18
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+describe('useSession', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock) = jest.fn();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+    localStorage.clear();
+  });
+
+  test('resumes existing session', async () => {
+    localStorage.setItem('sessionId', 'abc');
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ threadId: 'abc', current_step: 'planning', workflow_type: 'meal_planning' })
+    });
+    const startSession = jest.fn();
+    const { result } = renderHook(() => useSession(startSession), { wrapper });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(result.current.resumeData?.threadId).toBe('abc');
+    expect(result.current.isResuming).toBe(false);
+  });
+
+  test('clears session when workflow complete', async () => {
+    localStorage.setItem('sessionId', 'done');
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ threadId: 'done', current_step: 'complete' })
+    });
+    const { result } = renderHook(() => useSession(jest.fn()), { wrapper });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(localStorage.getItem('sessionId')).toBeNull();
+    expect(result.current.resumeData).toBeUndefined();
+  });
+
+  test('startNewSession abandons existing session', async () => {
+    localStorage.setItem('sessionId', 'old');
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ threadId: 'old', current_step: 'planning' }) })
+      .mockResolvedValueOnce({ ok: true });
+    const startSession = jest.fn();
+    const { result } = renderHook(() => useSession(startSession), { wrapper });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    await act(async () => {
+      await result.current.startNewSession();
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/workflows/old/abandon', { method: 'POST' });
+    expect(localStorage.getItem('sessionId')).toBeNull();
+    expect(startSession).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create new tests for `MealPlanDisplay`, `Toast` component, and `useSession` hook
- update agent tests to use current meal plan field names and indexes

## Testing
- `yarn test`
- `yarn test:frontend`
- `yarn test:agent`


------
https://chatgpt.com/codex/tasks/task_e_6863132adc1483249867d847e1dcda62