### PR TITLE
Add HTTP checkpoint persistence

### DIFF
--- a/backend/handlers/checkpoints.go
+++ b/backend/handlers/checkpoints.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// GetCheckpoint handles GET /api/checkpoints/{thread_id}
+func GetCheckpoint(w http.ResponseWriter, r *http.Request) {
+	threadID := chi.URLParam(r, "thread_id")
+	if threadID == "" {
+		http.Error(w, "missing thread id", http.StatusBadRequest)
+		return
+	}
+	ns := r.URL.Query().Get("checkpoint_ns")
+	data, meta, found, err := Services.CheckpointService.GetCheckpoint(threadID, ns)
+	if err != nil {
+		http.Error(w, "failed to get checkpoint: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		writeJSON(w, map[string]any{"found": false})
+		return
+	}
+	var cp map[string]any
+	var md map[string]any
+	json.Unmarshal(data, &cp)
+	json.Unmarshal(meta, &md)
+	resp := map[string]any{
+		"found": true,
+		"tuple": map[string]any{
+			"checkpoint": cp,
+			"metadata":   md,
+		},
+	}
+	writeJSON(w, resp)
+}
+
+// PutCheckpoint handles POST /api/checkpoints
+func PutCheckpoint(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		ThreadID     string          `json:"thread_id"`
+		CheckpointNS string          `json:"checkpoint_ns"`
+		WorkflowType string          `json:"workflow_type"`
+		Checkpoint   json.RawMessage `json:"checkpoint"`
+		Metadata     json.RawMessage `json:"metadata"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.ThreadID == "" || req.CheckpointNS == "" {
+		http.Error(w, "thread_id and checkpoint_ns required", http.StatusBadRequest)
+		return
+	}
+	if err := Services.CheckpointService.PutCheckpoint(req.ThreadID, req.CheckpointNS, req.WorkflowType, req.Checkpoint, req.Metadata); err != nil {
+		http.Error(w, "failed to save checkpoint: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := map[string]any{
+		"success":       true,
+		"thread_id":     req.ThreadID,
+		"checkpoint_ns": req.CheckpointNS,
+	}
+	writeJSON(w, resp)
+}
+
+// ListCheckpoints handles GET /api/checkpoints
+func ListCheckpoints(w http.ResponseWriter, r *http.Request) {
+	limitStr := r.URL.Query().Get("limit")
+	before := r.URL.Query().Get("before")
+	limit := 100
+	if limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil {
+			limit = v
+		}
+	}
+	recs, err := Services.CheckpointService.ListCheckpoints(limit, before)
+	if err != nil {
+		http.Error(w, "failed to list checkpoints: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	entries := []map[string]any{}
+	for _, r := range recs {
+		var cp map[string]any
+		var md map[string]any
+		json.Unmarshal(r.Checkpoint, &cp)
+		json.Unmarshal(r.Metadata, &md)
+		entries = append(entries, map[string]any{
+			"thread_id":     r.ThreadID,
+			"checkpoint_ns": r.CheckpointNS,
+			"tuple": map[string]any{
+				"checkpoint": cp,
+				"metadata":   md,
+			},
+		})
+	}
+	writeJSON(w, map[string]any{"entries": entries})
+}

--- a/backend/handlers/checkpoints_test.go
+++ b/backend/handlers/checkpoints_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/mock"
+	"mealplanner/services"
+)
+
+type MockCheckpointService struct{ mock.Mock }
+
+func (m *MockCheckpointService) GetCheckpoint(tid, ns string) ([]byte, []byte, bool, error) {
+	args := m.Called(tid, ns)
+	return []byte(args.String(0)), []byte(args.String(1)), args.Bool(2), args.Error(3)
+}
+func (m *MockCheckpointService) PutCheckpoint(tid, ns, wt string, cp []byte, md []byte) error {
+	args := m.Called(tid, ns, wt, cp, md)
+	return args.Error(0)
+}
+func (m *MockCheckpointService) ListCheckpoints(limit int, before string) ([]services.CheckpointRecord, error) {
+	args := m.Called(limit, before)
+	return args.Get(0).([]services.CheckpointRecord), args.Error(1)
+}
+
+func TestGetCheckpointNotFound(t *testing.T) {
+	svc := new(MockCheckpointService)
+	svc.On("GetCheckpoint", "abc", "").Return("", "", false, nil)
+	original := Services
+	Services = &services.ServiceContainer{CheckpointService: svc}
+	defer func() { Services = original }()
+
+	req := httptest.NewRequest("GET", "/api/checkpoints/abc", nil)
+	rc := chi.NewRouteContext()
+	rc.URLParams.Add("thread_id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rc))
+
+	rr := httptest.NewRecorder()
+	GetCheckpoint(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp["found"].(bool) {
+		t.Fatalf("expected found=false")
+	}
+	svc.AssertExpectations(t)
+}
+
+func TestPutCheckpointSuccess(t *testing.T) {
+	svc := new(MockCheckpointService)
+	original := Services
+	Services = &services.ServiceContainer{CheckpointService: svc}
+	defer func() { Services = original }()
+
+	body := map[string]any{
+		"thread_id":     "t1",
+		"checkpoint_ns": "n1",
+		"workflow_type": "meal_planning",
+		"checkpoint":    map[string]any{},
+		"metadata":      map[string]any{},
+	}
+	b, _ := json.Marshal(body)
+	svc.On("PutCheckpoint", "t1", "n1", "meal_planning", mock.Anything, mock.Anything).Return(nil)
+	req := httptest.NewRequest("POST", "/api/checkpoints", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+	PutCheckpoint(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	if !resp["success"].(bool) {
+		t.Fatalf("expected success true")
+	}
+	svc.AssertExpectations(t)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -314,6 +314,11 @@ func main() {
 	r.Get("/api/meals/{mealId}/steps", handlers.GetStepsHandler)
 	r.Post("/api/meals/{mealId}/steps", handlers.AddStepHandler)
 	r.Post("/api/meals/{mealId}/steps/bulk", handlers.AddBulkStepsHandler)
+
+	// Checkpoint persistence endpoints
+	r.Get("/api/checkpoints/{thread_id}", handlers.GetCheckpoint)
+	r.Post("/api/checkpoints", handlers.PutCheckpoint)
+	r.Get("/api/checkpoints", handlers.ListCheckpoints)
 	r.Route("/api/agent", func(r chi.Router) {
 		r.Post("/start", handlers.StartAgentWorkflow)
 		r.Post("/message", handlers.MessageAgentHandler)

--- a/backend/services/checkpoint_service.go
+++ b/backend/services/checkpoint_service.go
@@ -1,0 +1,63 @@
+package services
+
+import (
+	"database/sql"
+)
+
+type checkpointService struct {
+	db *sql.DB
+}
+
+// NewCheckpointService creates a new checkpoint service
+func NewCheckpointService(db *sql.DB) CheckpointService {
+	return &checkpointService{db: db}
+}
+
+func (s *checkpointService) GetCheckpoint(threadID, ns string) ([]byte, []byte, bool, error) {
+	var query string
+	var args []any
+	if ns != "" {
+		query = `SELECT checkpoint_data, metadata FROM workflow_checkpoints WHERE thread_id=$1 AND checkpoint_ns=$2`
+		args = []any{threadID, ns}
+	} else {
+		query = `SELECT checkpoint_data, metadata FROM workflow_checkpoints WHERE thread_id=$1 ORDER BY updated_at DESC LIMIT 1`
+		args = []any{threadID}
+	}
+	var data []byte
+	var meta []byte
+	err := s.db.QueryRow(query, args...).Scan(&data, &meta)
+	if err == sql.ErrNoRows {
+		return nil, nil, false, nil
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return data, meta, true, nil
+}
+
+func (s *checkpointService) PutCheckpoint(threadID, ns, workflowType string, checkpoint []byte, metadata []byte) error {
+	const query = `INSERT INTO workflow_checkpoints (thread_id, workflow_type, checkpoint_ns, checkpoint_data, metadata, created_at, updated_at)
+    VALUES ($1,$2,$3,$4,$5,NOW(),NOW())
+    ON CONFLICT (thread_id, checkpoint_ns) DO UPDATE SET checkpoint_data=EXCLUDED.checkpoint_data, metadata=EXCLUDED.metadata, updated_at=NOW()`
+	_, err := s.db.Exec(query, threadID, workflowType, ns, checkpoint, metadata)
+	return err
+}
+
+func (s *checkpointService) ListCheckpoints(limit int, before string) ([]CheckpointRecord, error) {
+	query := `SELECT thread_id, checkpoint_ns, checkpoint_data, metadata FROM workflow_checkpoints ORDER BY thread_id DESC LIMIT $1`
+	args := []any{limit}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var recs []CheckpointRecord
+	for rows.Next() {
+		var r CheckpointRecord
+		if err := rows.Scan(&r.ThreadID, &r.CheckpointNS, &r.Checkpoint, &r.Metadata); err != nil {
+			return nil, err
+		}
+		recs = append(recs, r)
+	}
+	return recs, nil
+}

--- a/backend/services/interfaces.go
+++ b/backend/services/interfaces.go
@@ -88,6 +88,21 @@ type WorkflowService interface {
 	AddUserFeedback(threadID, from, message, timestamp string) error
 }
 
+// CheckpointService handles low level checkpoint persistence
+type CheckpointService interface {
+	GetCheckpoint(threadID, checkpointNS string) (checkpoint []byte, metadata []byte, found bool, err error)
+	PutCheckpoint(threadID, checkpointNS, workflowType string, checkpoint []byte, metadata []byte) error
+	ListCheckpoints(limit int, before string) ([]CheckpointRecord, error)
+}
+
+// CheckpointRecord represents a checkpoint entry
+type CheckpointRecord struct {
+	ThreadID     string
+	CheckpointNS string
+	Checkpoint   []byte
+	Metadata     []byte
+}
+
 // ServiceContainer holds all service dependencies
 type ServiceContainer struct {
 	MealService         MealService
@@ -97,4 +112,5 @@ type ServiceContainer struct {
 	ShoppingListService ShoppingListService
 	MessageService      MessageService
 	WorkflowService     WorkflowService
+	CheckpointService   CheckpointService
 }

--- a/backend/services/service_container.go
+++ b/backend/services/service_container.go
@@ -14,5 +14,6 @@ func NewServiceContainer(db *sql.DB) *ServiceContainer {
 		ShoppingListService: NewShoppingListService(db),
 		MessageService:      SQLMessageService(db),
 		WorkflowService:     NewWorkflowService(db),
+		CheckpointService:   NewCheckpointService(db),
 	}
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -6,6 +6,7 @@ option go_package = "mealplanner/generated/go/apipb";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
 
 // Core data models
 
@@ -392,6 +393,64 @@ message UpdateSessionStateResponse {
   string message = 1;
 }
 
+// LangGraph checkpoint persistence
+message AgentCheckpoint {
+  map<string, google.protobuf.Any> channel_values = 1;
+  repeated string next = 2;
+  int32 step = 3;
+}
+
+message AgentCheckpointMetadata {
+  string source = 1;
+  int32 step = 2;
+  map<string, google.protobuf.Any> writes = 3;
+  map<string, google.protobuf.Any> additional_fields = 4;
+}
+
+message CheckpointTuple {
+  AgentCheckpoint checkpoint = 1;
+  AgentCheckpointMetadata metadata = 2;
+}
+
+message GetCheckpointRequest {
+  string thread_id = 1;
+  string checkpoint_ns = 2; // optional - if empty, fetch latest
+}
+
+message GetCheckpointResponse {
+  CheckpointTuple tuple = 1;
+  bool found = 2;
+}
+
+message PutCheckpointRequest {
+  string thread_id = 1;
+  string checkpoint_ns = 2;
+  string workflow_type = 3;
+  AgentCheckpoint checkpoint = 4;
+  AgentCheckpointMetadata metadata = 5;
+}
+
+message PutCheckpointResponse {
+  bool success = 1;
+  string thread_id = 2;
+  string checkpoint_ns = 3;
+}
+
+message ListCheckpointsRequest {
+  int32 limit = 1;
+  string before_thread_id = 2; // optional pagination
+}
+
+message ListCheckpointsResponse {
+  repeated CheckpointEntry entries = 1;
+}
+
+message CheckpointEntry {
+  string thread_id = 1;
+  string checkpoint_ns = 2;
+  CheckpointTuple tuple = 3;
+}
+
 // Service definition
 service MealPlannerAPI {
   // Health endpoints
@@ -438,4 +497,9 @@ service MealPlannerAPI {
   rpc AbandonWorkflow(AbandonWorkflowRequest) returns (AbandonWorkflowResponse);
   rpc AddMessage(AddMessageRequest) returns (AddMessageResponse);
   rpc UpdateSessionState(UpdateSessionStateRequest) returns (UpdateSessionStateResponse);
+
+  // Checkpoint persistence endpoints
+  rpc GetCheckpoint(GetCheckpointRequest) returns (GetCheckpointResponse);
+  rpc PutCheckpoint(PutCheckpointRequest) returns (PutCheckpointResponse);
+  rpc ListCheckpoints(ListCheckpointsRequest) returns (ListCheckpointsResponse);
 }

--- a/proto/google/protobuf/any.proto
+++ b/proto/google/protobuf/any.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package google.protobuf;
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}

--- a/proto/google/protobuf/empty.proto
+++ b/proto/google/protobuf/empty.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package google.protobuf;
+option go_package = "google.golang.org/protobuf/types/known/emptypb";
+message Empty {}

--- a/proto/google/protobuf/timestamp.proto
+++ b/proto/google/protobuf/timestamp.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package google.protobuf;
+option go_package = "google.golang.org/protobuf/types/known/timestamppb";
+message Timestamp {
+  int64 seconds = 1;
+  int32 nanos = 2;
+}

--- a/typescript/agent/manager.ts
+++ b/typescript/agent/manager.ts
@@ -2,9 +2,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { RunnableConfig } from '@langchain/core/runnables';
 import { WorkflowType } from './shared/types';
 import {
-  PostgresCheckpointSaver,
   PostgresCheckpointConfig,
 } from './shared/checkpointer';
+import { HttpCheckpointSaver } from './shared/httpCheckpointer';
 import { WorkflowRegistry } from './registry';
 import { debugLog } from './cli';
 
@@ -26,29 +26,26 @@ export interface WorkflowExecutionOptions {
 }
 
 export class WorkflowManager {
-  private checkpointer: PostgresCheckpointSaver;
+  private checkpointer: HttpCheckpointSaver;
   private registry: WorkflowRegistry;
   private activeSessions = new Map<string, WorkflowSession>();
 
   constructor(dbConfig: PostgresCheckpointConfig, registry: WorkflowRegistry) {
-    this.checkpointer = new PostgresCheckpointSaver(dbConfig);
+    this.checkpointer = new HttpCheckpointSaver();
     this.registry = registry;
   }
 
   // Public getter for checkpointer
-  getCheckpointer(): PostgresCheckpointSaver {
+  getCheckpointer(): HttpCheckpointSaver {
     return this.checkpointer;
   }
 
   async initialize(): Promise<void> {
-    // No need to explicitly connect anymore as we're using connection pooling
     await this.loadActiveSessions();
   }
 
   async shutdown(): Promise<void> {
     await this.registry.cleanupAll();
-    // This will close the connection pool
-    await this.checkpointer.disconnect();
   }
 
   // Start a new workflow session

--- a/typescript/agent/package.json
+++ b/typescript/agent/package.json
@@ -15,14 +15,12 @@
     "@modelcontextprotocol/sdk": "1.12.3",
     "commander": "^14.0.0",
     "dotenv": "^16.5.0",
-    "pg": "^8.11.0",
     "uuid": "^9.0.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",
     "@types/node": "^20.0.0",
-    "@types/pg": "^8.10.0",
     "@types/uuid": "^9.0.0",
     "jest": "^30.0.0",
     "ts-jest": "^29.1.1",

--- a/typescript/agent/registry.ts
+++ b/typescript/agent/registry.ts
@@ -1,5 +1,5 @@
 import { WorkflowType } from './shared/types';
-import { PostgresCheckpointSaver } from './shared/checkpointer';
+import { HttpCheckpointSaver } from './shared/httpCheckpointer';
 
 // Base workflow interface
 export interface BaseWorkflow {
@@ -11,7 +11,7 @@ export interface BaseWorkflow {
 
 // Workflow factory interface
 export interface WorkflowFactory {
-  create(checkpointer: PostgresCheckpointSaver): Promise<BaseWorkflow>;
+  create(checkpointer: HttpCheckpointSaver): Promise<BaseWorkflow>;
   getType(): WorkflowType;
 }
 
@@ -26,7 +26,7 @@ export class WorkflowRegistry {
 
   async createWorkflow(
     type: WorkflowType,
-    checkpointer: PostgresCheckpointSaver,
+    checkpointer: HttpCheckpointSaver,
   ): Promise<BaseWorkflow> {
     console.log(`Creating workflow of type: ${type}`);
     const factory = this.factories.get(type);
@@ -43,7 +43,7 @@ export class WorkflowRegistry {
   async getOrCreateWorkflow(
     type: WorkflowType,
     threadId: string,
-    checkpointer: PostgresCheckpointSaver,
+    checkpointer: HttpCheckpointSaver,
   ): Promise<BaseWorkflow> {
     const key = `${type}:${threadId}`;
 

--- a/typescript/agent/shared/httpCheckpointer.ts
+++ b/typescript/agent/shared/httpCheckpointer.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from 'uuid';
+import { RunnableConfig } from '@langchain/core/runnables';
+import { AgentCheckpoint, AgentCheckpointMetadata } from '../../../generated/ts/api';
+
+export class HttpCheckpointSaver {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = 'http://localhost:8090') {
+    this.baseUrl = baseUrl;
+  }
+
+  async getTuple(config: RunnableConfig): Promise<[AgentCheckpoint, AgentCheckpointMetadata] | undefined> {
+    const threadId = (config as any).configurable?.threadId;
+    const checkpointNs = (config as any).configurable?.checkpoint_ns;
+    if (!threadId) return undefined;
+    const url = `${this.baseUrl}/api/checkpoints/${threadId}${checkpointNs ? `?checkpoint_ns=${checkpointNs}` : ''}`;
+    const resp = await fetch(url);
+    if (!resp.ok) return undefined;
+    const data = await resp.json();
+    return data.found ? [data.tuple.checkpoint, data.tuple.metadata] : undefined;
+  }
+
+  async put(config: RunnableConfig, checkpoint: AgentCheckpoint, metadata: AgentCheckpointMetadata): Promise<RunnableConfig> {
+    const threadId = (config as any).configurable?.threadId || uuidv4();
+    const checkpointNs = (config as any).configurable?.checkpoint_ns || uuidv4();
+    const resp = await fetch(`${this.baseUrl}/api/checkpoints`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        thread_id: threadId,
+        checkpoint_ns: checkpointNs,
+        workflow_type: (metadata as any).workflow_type || 'meal_planning',
+        checkpoint,
+        metadata,
+      }),
+    });
+    if (!resp.ok) throw new Error(`Failed to save checkpoint: ${resp.statusText}`);
+    return { configurable: { ...(config as any).configurable, threadId, checkpoint_ns: checkpointNs } } as RunnableConfig;
+  }
+
+  async *list(config: RunnableConfig, limit?: number): AsyncGenerator<[RunnableConfig, AgentCheckpoint, AgentCheckpointMetadata]> {
+    const resp = await fetch(`${this.baseUrl}/api/checkpoints?limit=${limit || 100}`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    for (const entry of data.entries) {
+      yield [{ configurable: { threadId: entry.thread_id, checkpoint_ns: entry.checkpoint_ns } } as RunnableConfig, entry.tuple.checkpoint, entry.tuple.metadata];
+    }
+  }
+}

--- a/typescript/agent/tests/meal-planning.integration.test.ts
+++ b/typescript/agent/tests/meal-planning.integration.test.ts
@@ -1,11 +1,11 @@
 import { MealPlanningWorkflow } from '../workflows/meal-planning';
 import { MealPlanningStep } from '../shared/types';
 import { WeeklyMealPlan } from '@mealplanner/generated';
-import { PostgresCheckpointSaver } from '../shared/checkpointer';
+import { HttpCheckpointSaver } from '../shared/httpCheckpointer';
 
 describe('MealPlanningWorkflow LLM integration and edge cases', () => {
   let workflow: any;
-  const mockCheckpointer = {} as PostgresCheckpointSaver;
+  const mockCheckpointer = {} as HttpCheckpointSaver;
 
   beforeAll(() => {
     workflow = new MealPlanningWorkflow(mockCheckpointer) as any;

--- a/typescript/agent/tests/meal-planning.test.ts
+++ b/typescript/agent/tests/meal-planning.test.ts
@@ -1,11 +1,11 @@
 import { MealPlanningWorkflow } from '../workflows/meal-planning';
 import { VALIDATION_CRITERIA } from '../shared/types';
 import type { WeeklyMealPlan } from '@mealplanner/generated';
-import { PostgresCheckpointSaver } from '../shared/checkpointer';
+import { HttpCheckpointSaver } from '../shared/httpCheckpointer';
 
 describe('MealPlanningWorkflow logic', () => {
   let workflow: any;
-  const mockCheckpointer = {} as PostgresCheckpointSaver;
+  const mockCheckpointer = {} as HttpCheckpointSaver;
 
   beforeAll(() => {
     workflow = new MealPlanningWorkflow(mockCheckpointer) as any;

--- a/typescript/agent/workflows/factories.ts
+++ b/typescript/agent/workflows/factories.ts
@@ -1,10 +1,10 @@
 import { WorkflowType } from '../shared/types';
 import { WorkflowFactory, BaseWorkflow } from '../registry';
-import { PostgresCheckpointSaver } from '../shared/checkpointer';
+import { HttpCheckpointSaver } from '../shared/httpCheckpointer';
 import { MealPlanningWorkflow } from './meal-planning';
 
 export class MealPlanningWorkflowFactory implements WorkflowFactory {
-  async create(checkpointer: PostgresCheckpointSaver): Promise<BaseWorkflow> {
+  async create(checkpointer: HttpCheckpointSaver): Promise<BaseWorkflow> {
     return new MealPlanningWorkflow(checkpointer);
   }
 

--- a/typescript/agent/workflows/feedback-handler.ts
+++ b/typescript/agent/workflows/feedback-handler.ts
@@ -3,7 +3,7 @@ import {
   MealPlanningState,
   WorkflowType,
 } from '../shared/types';
-import { PostgresCheckpointSaver } from '../shared/checkpointer';
+import { HttpCheckpointSaver } from '../shared/httpCheckpointer';
 
 export interface FeedbackInput {
   threadId: string;
@@ -13,9 +13,9 @@ export interface FeedbackInput {
 }
 
 export class FeedbackHandler {
-  private checkpointer: PostgresCheckpointSaver;
+  private checkpointer: HttpCheckpointSaver;
 
-  constructor(checkpointer: PostgresCheckpointSaver) {
+  constructor(checkpointer: HttpCheckpointSaver) {
     this.checkpointer = checkpointer;
   }
 

--- a/typescript/agent/workflows/meal-planning.ts
+++ b/typescript/agent/workflows/meal-planning.ts
@@ -17,7 +17,7 @@ import {
 } from '../shared/types';
 import { BaseWorkflow } from '../registry';
 import { debugLog } from '../cli';
-import { PostgresCheckpointSaver } from '../shared/checkpointer';
+import { HttpCheckpointSaver } from '../shared/httpCheckpointer';
 import { FeedbackHandler } from './feedback-handler';
 import {
   ShoppingListResponse,
@@ -57,10 +57,10 @@ export class MealPlanningWorkflow implements BaseWorkflow {
   private client: Client;
   private llm: any;
   private nanoLlm: any;
-  private checkpointer: PostgresCheckpointSaver;
+  private checkpointer: HttpCheckpointSaver;
   private feedbackHandler: FeedbackHandler;
 
-  constructor(checkpointer: PostgresCheckpointSaver) {
+  constructor(checkpointer: HttpCheckpointSaver) {
     this.saveMealPlan = this.saveMealPlan.bind(this);
     this.checkpointer = checkpointer;
     this.feedbackHandler = new FeedbackHandler(checkpointer);


### PR DESCRIPTION
## Summary
- define checkpoint messages in `api.proto`
- implement checkpoint handlers and service in Go backend
- add HTTP-based checkpoint saver for TS agent
- wire checkpoint routes into backend router
- replace PG checkpointer usage across TS agent
- include basic tests for checkpoint handlers

## Testing
- `yarn test:backend`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686c87ee70888324b609c9a12000ab4c