### PR TITLE
Replace custom agent structs with protobuf types

### DIFF
--- a/backend/handlers/agent.go
+++ b/backend/handlers/agent.go
@@ -57,7 +57,7 @@ func runAgentCLI(ctx context.Context, args ...string) (models.AgentResponse, err
 
 	// Attempt to unmarshal stdout only
 	var resp models.AgentResponse
-	if err := json.Unmarshal(stdoutBuffer.Bytes(), &resp); err != nil {
+	if err := protojson.Unmarshal(stdoutBuffer.Bytes(), &resp); err != nil {
 		// If unmarshal fails, return an error including the stdout that failed to parse
 		return models.AgentResponse{}, fmt.Errorf("failed to unmarshal agent response: %v\nStdout: %s", err, stdoutBuffer.String()) // Include stdoutBuffer for context
 	}
@@ -76,7 +76,7 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentStartRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -89,13 +89,13 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Initialize workflow checkpoint
-	if resp.ThreadID == "" {
+	if resp.ThreadId == "" {
 		http.Error(w, "failed to start workflow: missing thread ID", http.StatusInternalServerError)
 		logger.Errorw("No thread ID returned from agent CLI on start", "req", req)
 		return
 	}
 	// Seed full workflow state into checkpoint
-	if resp.InitialState != nil {
+	if resp.InitialState != "" {
 		checkpoint := map[string]interface{}{
 			"channel_values": resp.InitialState,
 			"next":           []interface{}{},
@@ -103,14 +103,14 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		}
 		if data, err := json.Marshal(checkpoint); err != nil {
 			logger.Errorw("Failed to serialize initial checkpoint", "error", err)
-		} else if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadID, data); err != nil {
+		} else if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadId, data); err != nil {
 			logger.Errorw("Failed to initialize workflow checkpoint", "error", err)
 		}
 	}
 	// Add initial agent message if present
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadId, resp.Message, t); err != nil {
 			logger.Errorw("Failed to add agent message", "error", err)
 		}
 	}
@@ -141,14 +141,14 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentFeedbackRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Store user message in database
 	if req.From == "user" && req.Message != "" {
-		_, err := Services.WorkflowService.AddMessage(req.ThreadID, "user", req.Message)
+		_, err := Services.WorkflowService.AddMessage(req.ThreadId, "user", req.Message)
 		if err != nil {
 			logger.Infof("[ERROR AddAgentFeedback] Failed to store user message: %v", err)
 		}
@@ -156,8 +156,8 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	logger.Infof("[DEBUG AddAgentFeedback] Running agent CLI: plan feedback %s %s --from %s", req.ThreadID, req.Message, req.From)
-	resp, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadID, req.Message, "--from", req.From)
+	logger.Infof("[DEBUG AddAgentFeedback] Running agent CLI: plan feedback %s %s --from %s", req.ThreadId, req.Message, req.From)
+	resp, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadId, req.Message, "--from", req.From)
 	if err != nil {
 		logger.Infof("[ERROR AddAgentFeedback] agent CLI error: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -168,7 +168,7 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 	// Append agent message to workflow checkpoint
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(req.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(req.ThreadId, resp.Message, t); err != nil {
 			logger.Infof("[ERROR AddAgentFeedback] Failed to add agent message: %v", err)
 		}
 	}
@@ -188,13 +188,13 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentResumeRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	args := []string{"resume", req.ThreadID}
+	args := []string{"resume", req.ThreadId}
 
 	if req.Interactive {
 		args = append(args, "--interactive")
@@ -205,7 +205,7 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if resp.ThreadID == "" {
+	if resp.ThreadId == "" {
 		http.Error(w, "failed to resume workflow: missing thread ID", http.StatusInternalServerError)
 		logger.Errorw("No thread ID returned from agent CLI on resume", "req", req)
 		return
@@ -213,11 +213,12 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	// Merge updated data into workflow checkpoint
 	m := map[string]interface{}{}
 	// load existing checkpoint
-	if raw, _, err := Services.WorkflowService.GetWorkflowCheckpoint(resp.ThreadID); err == nil {
+	if raw, _, err := Services.WorkflowService.GetWorkflowCheckpoint(resp.ThreadId); err == nil {
 		json.Unmarshal(raw, &m)
 	}
-	if resp.Raw != nil {
-		if rawMap, ok := resp.Raw.(map[string]interface{}); ok {
+	if resp.Raw != "" {
+		var rawMap map[string]interface{}
+		if err := json.Unmarshal([]byte(resp.Raw), &rawMap); err == nil {
 			if mealPlan, ok := rawMap["meal_plan"]; ok {
 				m["meal_plan"] = mealPlan
 			}
@@ -229,14 +230,14 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	if data, err := json.Marshal(m); err != nil {
 		logger.Errorw("Failed to serialize updated checkpoint", "error", err)
 	} else {
-		if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadID, data); err != nil {
+		if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadId, data); err != nil {
 			logger.Errorw("Failed to update workflow checkpoint", "error", err)
 		}
 	}
 	// Add agent message if present
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadId, resp.Message, t); err != nil {
 			logger.Errorw("Failed to add agent message", "error", err)
 		}
 	}
@@ -256,14 +257,14 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentMessageRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	// Append user message to workflow checkpoint
 	if req.From == "user" && req.Message != "" {
 		t := time.Now().Format(time.RFC3339)
-		if err := Services.WorkflowService.AddUserFeedback(req.ThreadID, req.From, req.Message, t); err != nil {
+		if err := Services.WorkflowService.AddUserFeedback(req.ThreadId, req.From, req.Message, t); err != nil {
 			logger.Infof("[ERROR MessageAgentHandler] Failed to add user feedback: %v", err)
 		} else {
 			logger.Infof("[MessageAgentHandler] Saved user message to FeedbackHistory: %q", req.Message)
@@ -272,14 +273,14 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	// Run feedback
-	logger.Infof("[DEBUG MessageAgentHandler] Running agent CLI: plan feedback %s %s --from %s", req.ThreadID, req.Message, req.From)
-	if _, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadID, req.Message, "--from", req.From); err != nil {
+	logger.Infof("[DEBUG MessageAgentHandler] Running agent CLI: plan feedback %s %s --from %s", req.ThreadId, req.Message, req.From)
+	if _, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadId, req.Message, "--from", req.From); err != nil {
 		logger.Infof("[ERROR MessageAgentHandler] agent CLI feedback error: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	// Run resume
-	resumeArgs := []string{"resume", req.ThreadID}
+	resumeArgs := []string{"resume", req.ThreadId}
 	if req.Interactive {
 		resumeArgs = append(resumeArgs, "--interactive")
 	}
@@ -295,7 +296,7 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 	// Append agent response message to workflow checkpoint
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339)
-		if err := Services.WorkflowService.AddAgentMessage(req.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(req.ThreadId, resp.Message, t); err != nil {
 			logger.Infof("[ERROR MessageAgentHandler] Failed to add agent message: %v", err)
 		} else {
 			logger.Infof("[MessageAgentHandler] Saved agent message to AgentMessages: %q", resp.Message)

--- a/backend/handlers/workflows_test.go
+++ b/backend/handlers/workflows_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	apipb "mealplanner/generated/go"
 	"mealplanner/models"
 	"mealplanner/services"
 
@@ -236,7 +237,7 @@ func TestGetWorkflowStateReturnsShoppingList(t *testing.T) {
 	threadID := "thread123"
 	plan := &models.MealPlanIdentifier{ID: 1, ThreadID: threadID}
 	entries := []models.MealPlanEntry{
-		{DayOfWeek: 0, MealType: "breakfast", Meal: map[string]interface{}{"id": plan.ID, "name": "Test Meal"}},
+		{DayOfWeek: 0, MealType: "breakfast", Meal: &apipb.Meal{Id: int32(plan.ID), Name: "Test Meal"}},
 	}
 	shoppingItems := []models.ShoppingListItem{
 		{Ingredient: "Eggs", Quantity: "12"},

--- a/backend/models/agent.go
+++ b/backend/models/agent.go
@@ -2,16 +2,15 @@ package models
 
 import (
 	"errors"
+
+	apipb "mealplanner/generated/go"
 )
 
 // AgentStartRequest represents a request to start a workflow
 // Example JSON: {"participants":["brad","shannon"],"workflowType":"meal_planning"}
-type AgentStartRequest struct {
-	Participants []string `json:"participants"`
-	WorkflowType string   `json:"workflowType"`
-}
+type AgentStartRequest = apipb.AgentStartRequest
 
-func (r *AgentStartRequest) Validate() error {
+func ValidateAgentStartRequest(r *AgentStartRequest) error {
 	if len(r.Participants) == 0 {
 		return errors.New("participants required")
 	}
@@ -23,14 +22,10 @@ func (r *AgentStartRequest) Validate() error {
 
 // AgentFeedbackRequest represents feedback for a workflow
 // Example JSON: {"threadId":"uuid","message":"text","from":"brad"}
-type AgentFeedbackRequest struct {
-	ThreadID string `json:"threadId"`
-	Message  string `json:"message"`
-	From     string `json:"from"`
-}
+type AgentFeedbackRequest = apipb.AgentFeedbackRequest
 
-func (r *AgentFeedbackRequest) Validate() error {
-	if r.ThreadID == "" {
+func ValidateAgentFeedbackRequest(r *AgentFeedbackRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	if r.Message == "" {
@@ -44,13 +39,10 @@ func (r *AgentFeedbackRequest) Validate() error {
 
 // AgentResumeRequest represents a resume request
 // Example JSON: {"threadId":"uuid","interactive":false}
-type AgentResumeRequest struct {
-	ThreadID    string `json:"threadId"`
-	Interactive bool   `json:"interactive"`
-}
+type AgentResumeRequest = apipb.AgentResumeRequest
 
-func (r *AgentResumeRequest) Validate() error {
-	if r.ThreadID == "" {
+func ValidateAgentResumeRequest(r *AgentResumeRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	return nil
@@ -58,16 +50,11 @@ func (r *AgentResumeRequest) Validate() error {
 
 // AgentMessageRequest represents a combined feedback and resume request
 // Example JSON: {"threadId":"uuid","message":"text","from":"user","interactive":false}
-type AgentMessageRequest struct {
-	ThreadID    string `json:"threadId"`
-	Message     string `json:"message"`
-	From        string `json:"from"`
-	Interactive bool   `json:"interactive"`
-}
+type AgentMessageRequest = apipb.AgentMessageRequest
 
-// Validate ensures AgentMessageRequest has required fields
-func (r *AgentMessageRequest) Validate() error {
-	if r.ThreadID == "" {
+// ValidateAgentMessageRequest ensures AgentMessageRequest has required fields
+func ValidateAgentMessageRequest(r *AgentMessageRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	if r.Message == "" {
@@ -85,20 +72,8 @@ func (r *AgentMessageRequest) Validate() error {
 // CurrentStep is the agent's workflow step
 // MealPlan or other data may be embedded in Raw
 
-type AgentResponse struct {
-	Success      bool        `json:"success"`
-	Message      string      `json:"message,omitempty"`
-	ThreadID     string      `json:"threadId,omitempty"`
-	CurrentStep  string      `json:"currentStep,omitempty"`
-	InitialState interface{} `json:"initialState,omitempty"`
-	Raw          interface{} `json:"raw,omitempty"`
-}
+type AgentResponse = apipb.AgentResponse
 
 // WorkflowStatus represents high level workflow info
 // {"threadId":"uuid","workflowType":"meal_planning","currentStep":"step","participants":["brad"]}
-type WorkflowStatus struct {
-	ThreadID     string   `json:"threadId"`
-	WorkflowType string   `json:"workflowType"`
-	CurrentStep  string   `json:"currentStep"`
-	Participants []string `json:"participants"`
-}
+type WorkflowStatus = apipb.WorkflowStatus

--- a/backend/models/agent_test.go
+++ b/backend/models/agent_test.go
@@ -4,49 +4,49 @@ import "testing"
 
 func TestAgentStartRequestValidate(t *testing.T) {
 	req := AgentStartRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentStartRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
 	req.Participants = []string{"a"}
 	req.WorkflowType = "meal_planning"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentStartRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentFeedbackRequestValidate(t *testing.T) {
 	req := AgentFeedbackRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentFeedbackRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
+	req.ThreadId = "id"
 	req.Message = "msg"
 	req.From = "brad"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentFeedbackRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentResumeRequestValidate(t *testing.T) {
 	req := AgentResumeRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentResumeRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
-	if err := req.Validate(); err != nil {
+	req.ThreadId = "id"
+	if err := ValidateAgentResumeRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentMessageRequestValidate(t *testing.T) {
 	req := AgentMessageRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentMessageRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
+	req.ThreadId = "id"
 	req.Message = "hello"
 	req.From = "brad"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentMessageRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/backend/models/mealplan_sql_test.go
+++ b/backend/models/mealplan_sql_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	apipb "mealplanner/generated/go"
 )
 
 func TestSaveMealPlan_Success(t *testing.T) {
@@ -17,7 +18,7 @@ func TestSaveMealPlan_Success(t *testing.T) {
 
 	threadID := "thread1"
 	version := 1
-	testMeal := map[string]interface{}{"id": 101, "name": "Test Meal"}
+	testMeal := &apipb.Meal{Id: 101, Name: "Test Meal"}
 	entries := []MealPlanEntry{
 		{DayOfWeek: 0, MealType: "breakfast", Meal: testMeal},
 	}
@@ -80,9 +81,10 @@ func TestGetMealPlanItems_Success(t *testing.T) {
 	items, err := GetMealPlanItems(db, mealPlanID)
 	assert.NoError(t, err)
 	assert.Len(t, items, 1)
-	assert.Equal(t, 1, items[0].DayOfWeek)
+	assert.Equal(t, int32(1), items[0].DayOfWeek)
 	assert.Equal(t, "lunch", items[0].MealType)
-	assert.Equal(t, testMealJSON, items[0].Meal)
+	assert.Equal(t, int32(202), items[0].Meal.Id)
+	assert.Equal(t, "Test Lunch Meal", items[0].Meal.Name)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/generated/ts/google/protobuf/any.d.ts
+++ b/generated/ts/google/protobuf/any.d.ts
@@ -1,0 +1,5 @@
+export interface Any {
+  type_url?: string;
+  value?: Uint8Array;
+}
+export declare const Any: Any;

--- a/generated/ts/google/protobuf/any.js
+++ b/generated/ts/google/protobuf/any.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// Minimal Any implementation for tests

--- a/generated/ts/google/protobuf/any.ts
+++ b/generated/ts/google/protobuf/any.ts
@@ -1,0 +1,5 @@
+// Code generated manually as placeholder for tests
+export interface Any {
+  type_url?: string;
+  value?: Uint8Array;
+}


### PR DESCRIPTION
## Summary
- remove bespoke agent request/response structs and use protobuf messages
- provide validation helpers for protobuf requests
- switch agent CLI JSON parsing to use protojson
- update tests for protobuf types
- add missing google protobuf Any stubs for frontend tests

## Testing
- `yarn test:backend`
- `yarn test:frontend`
- `yarn test:agent`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686d2a85ac0c8324b9a310c9dec082a6