### PR TITLE
Align backend models with protobuf definitions

### DIFF
--- a/backend/dummy/dummy.go
+++ b/backend/dummy/dummy.go
@@ -192,7 +192,7 @@ func GenerateWeeklyMealPlanStruct() (*models.WeeklyMealPlan, error) {
 	dayNames := models.DaysOfTheWeek
 	mealTypes := []string{"breakfast", "lunch", "dinner"}
 
-	plan := &models.WeeklyMealPlan{Days: make([]models.PlanDay, 0, 21)}
+	plan := &models.WeeklyMealPlan{Days: make([]*models.PlanDay, 0, 21)}
 	for i, day := range dayNames {
 		for _, mt := range mealTypes {
 			minEffort, maxEffort := 0, 2
@@ -205,12 +205,12 @@ func GenerateWeeklyMealPlanStruct() (*models.WeeklyMealPlan, error) {
 				}
 			}
 			meal := pick(minEffort, maxEffort, mt)
-			plan.Days = append(plan.Days, models.PlanDay{DayIndex: i, MealType: mt, Meal: meal})
+			plan.Days = append(plan.Days, &models.PlanDay{DayIndex: int32(i), MealType: mt, Meal: meal})
 		}
 	}
 
 	for idx := range plan.Days {
-		if plan.Days[idx].DayIndex == 4 && plan.Days[idx].MealType == "dinner" {
+		if int(plan.Days[idx].DayIndex) == 4 && plan.Days[idx].MealType == "dinner" {
 			plan.Days[idx].Meal = &models.Meal{Name: "Eating out"}
 			break
 		}

--- a/backend/handlers/agent.go
+++ b/backend/handlers/agent.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"time"
 
+	apipb "mealplanner/generated/go"
 	"mealplanner/logging"
 	"mealplanner/models"
 
@@ -57,7 +58,7 @@ func runAgentCLI(ctx context.Context, args ...string) (models.AgentResponse, err
 
 	// Attempt to unmarshal stdout only
 	var resp models.AgentResponse
-	if err := json.Unmarshal(stdoutBuffer.Bytes(), &resp); err != nil {
+	if err := protojson.Unmarshal(stdoutBuffer.Bytes(), &resp); err != nil {
 		// If unmarshal fails, return an error including the stdout that failed to parse
 		return models.AgentResponse{}, fmt.Errorf("failed to unmarshal agent response: %v\nStdout: %s", err, stdoutBuffer.String()) // Include stdoutBuffer for context
 	}
@@ -71,12 +72,12 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	var req models.AgentStartRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var req apipb.AgentStartRequest
+	if err := protojson.Unmarshal(body, &req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentStartRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -89,13 +90,13 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Initialize workflow checkpoint
-	if resp.ThreadID == "" {
+	if resp.ThreadId == "" {
 		http.Error(w, "failed to start workflow: missing thread ID", http.StatusInternalServerError)
 		logger.Errorw("No thread ID returned from agent CLI on start", "req", req)
 		return
 	}
 	// Seed full workflow state into checkpoint
-	if resp.InitialState != nil {
+	if resp.InitialState != "" {
 		checkpoint := map[string]interface{}{
 			"channel_values": resp.InitialState,
 			"next":           []interface{}{},
@@ -103,14 +104,14 @@ func StartAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		}
 		if data, err := json.Marshal(checkpoint); err != nil {
 			logger.Errorw("Failed to serialize initial checkpoint", "error", err)
-		} else if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadID, data); err != nil {
+		} else if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadId, data); err != nil {
 			logger.Errorw("Failed to initialize workflow checkpoint", "error", err)
 		}
 	}
 	// Add initial agent message if present
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadId, resp.Message, t); err != nil {
 			logger.Errorw("Failed to add agent message", "error", err)
 		}
 	}
@@ -136,19 +137,19 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	var req models.AgentFeedbackRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var req apipb.AgentFeedbackRequest
+	if err := protojson.Unmarshal(body, &req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentFeedbackRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Store user message in database
 	if req.From == "user" && req.Message != "" {
-		_, err := Services.WorkflowService.AddMessage(req.ThreadID, "user", req.Message)
+		_, err := Services.WorkflowService.AddMessage(req.ThreadId, "user", req.Message)
 		if err != nil {
 			logger.Infof("[ERROR AddAgentFeedback] Failed to store user message: %v", err)
 		}
@@ -156,8 +157,8 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	logger.Infof("[DEBUG AddAgentFeedback] Running agent CLI: plan feedback %s %s --from %s", req.ThreadID, req.Message, req.From)
-	resp, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadID, req.Message, "--from", req.From)
+	logger.Infof("[DEBUG AddAgentFeedback] Running agent CLI: plan feedback %s %s --from %s", req.ThreadId, req.Message, req.From)
+	resp, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadId, req.Message, "--from", req.From)
 	if err != nil {
 		logger.Infof("[ERROR AddAgentFeedback] agent CLI error: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -168,7 +169,7 @@ func AddAgentFeedback(w http.ResponseWriter, r *http.Request) {
 	// Append agent message to workflow checkpoint
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(req.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(req.ThreadId, resp.Message, t); err != nil {
 			logger.Infof("[ERROR AddAgentFeedback] Failed to add agent message: %v", err)
 		}
 	}
@@ -183,18 +184,18 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	var req models.AgentResumeRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var req apipb.AgentResumeRequest
+	if err := protojson.Unmarshal(body, &req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentResumeRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	args := []string{"resume", req.ThreadID}
+	args := []string{"resume", req.ThreadId}
 
 	if req.Interactive {
 		args = append(args, "--interactive")
@@ -205,7 +206,7 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if resp.ThreadID == "" {
+	if resp.ThreadId == "" {
 		http.Error(w, "failed to resume workflow: missing thread ID", http.StatusInternalServerError)
 		logger.Errorw("No thread ID returned from agent CLI on resume", "req", req)
 		return
@@ -213,11 +214,12 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	// Merge updated data into workflow checkpoint
 	m := map[string]interface{}{}
 	// load existing checkpoint
-	if raw, _, err := Services.WorkflowService.GetWorkflowCheckpoint(resp.ThreadID); err == nil {
+	if raw, _, err := Services.WorkflowService.GetWorkflowCheckpoint(resp.ThreadId); err == nil {
 		json.Unmarshal(raw, &m)
 	}
-	if resp.Raw != nil {
-		if rawMap, ok := resp.Raw.(map[string]interface{}); ok {
+	if resp.Raw != "" {
+		var rawMap map[string]interface{}
+		if err := json.Unmarshal([]byte(resp.Raw), &rawMap); err == nil {
 			if mealPlan, ok := rawMap["meal_plan"]; ok {
 				m["meal_plan"] = mealPlan
 			}
@@ -229,14 +231,14 @@ func ResumeAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 	if data, err := json.Marshal(m); err != nil {
 		logger.Errorw("Failed to serialize updated checkpoint", "error", err)
 	} else {
-		if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadID, data); err != nil {
+		if err := Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadId, data); err != nil {
 			logger.Errorw("Failed to update workflow checkpoint", "error", err)
 		}
 	}
 	// Add agent message if present
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339) // use current local time
-		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(resp.ThreadId, resp.Message, t); err != nil {
 			logger.Errorw("Failed to add agent message", "error", err)
 		}
 	}
@@ -251,19 +253,19 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	var req models.AgentMessageRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var req apipb.AgentMessageRequest
+	if err := protojson.Unmarshal(body, &req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if err := req.Validate(); err != nil {
+	if err := models.ValidateAgentMessageRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	// Append user message to workflow checkpoint
 	if req.From == "user" && req.Message != "" {
 		t := time.Now().Format(time.RFC3339)
-		if err := Services.WorkflowService.AddUserFeedback(req.ThreadID, req.From, req.Message, t); err != nil {
+		if err := Services.WorkflowService.AddUserFeedback(req.ThreadId, req.From, req.Message, t); err != nil {
 			logger.Infof("[ERROR MessageAgentHandler] Failed to add user feedback: %v", err)
 		} else {
 			logger.Infof("[MessageAgentHandler] Saved user message to FeedbackHistory: %q", req.Message)
@@ -272,14 +274,14 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	// Run feedback
-	logger.Infof("[DEBUG MessageAgentHandler] Running agent CLI: plan feedback %s %s --from %s", req.ThreadID, req.Message, req.From)
-	if _, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadID, req.Message, "--from", req.From); err != nil {
+	logger.Infof("[DEBUG MessageAgentHandler] Running agent CLI: plan feedback %s %s --from %s", req.ThreadId, req.Message, req.From)
+	if _, err := runAgentCLI(ctx, "plan", "feedback", req.ThreadId, req.Message, "--from", req.From); err != nil {
 		logger.Infof("[ERROR MessageAgentHandler] agent CLI feedback error: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	// Run resume
-	resumeArgs := []string{"resume", req.ThreadID}
+	resumeArgs := []string{"resume", req.ThreadId}
 	if req.Interactive {
 		resumeArgs = append(resumeArgs, "--interactive")
 	}
@@ -295,7 +297,7 @@ func MessageAgentHandler(w http.ResponseWriter, r *http.Request) {
 	// Append agent response message to workflow checkpoint
 	if resp.Message != "" {
 		t := time.Now().Format(time.RFC3339)
-		if err := Services.WorkflowService.AddAgentMessage(req.ThreadID, resp.Message, t); err != nil {
+		if err := Services.WorkflowService.AddAgentMessage(req.ThreadId, resp.Message, t); err != nil {
 			logger.Infof("[ERROR MessageAgentHandler] Failed to add agent message: %v", err)
 		} else {
 			logger.Infof("[MessageAgentHandler] Saved agent message to AgentMessages: %q", resp.Message)

--- a/backend/handlers/mealplan.go
+++ b/backend/handlers/mealplan.go
@@ -42,7 +42,10 @@ func generateShoppingListForPlan(plan *models.WeeklyMealPlan) error {
 	if err != nil {
 		return err
 	}
-	plan.ShoppingList = items
+	plan.ShoppingList = make([]*models.ShoppingListItem, len(items))
+	for i := range items {
+		plan.ShoppingList[i] = &items[i]
+	}
 	return nil
 }
 
@@ -140,7 +143,7 @@ func SaveMealPlanHandler(w http.ResponseWriter, r *http.Request) {
 	version := int(req.Version)
 	if version <= 0 {
 		if latest, _ := Services.MealPlanService.GetLatestMealPlan(req.ThreadId); latest != nil {
-			version = latest.Version + 1
+			version = int(latest.Version) + 1
 		} else {
 			version = 1
 		}

--- a/backend/handlers/mealplan_ics_test.go
+++ b/backend/handlers/mealplan_ics_test.go
@@ -41,7 +41,7 @@ func (m *mockMealPlanService) GenerateWeeklyMealPlan() (*models.WeeklyMealPlan, 
 	}
 
 	plan := &models.WeeklyMealPlan{
-		Days: []models.PlanDay{
+		Days: []*models.PlanDay{
 			{DayIndex: 0, MealType: "dinner", Meal: testMeal},
 		},
 	}

--- a/backend/handlers/meals.go
+++ b/backend/handlers/meals.go
@@ -23,7 +23,7 @@ import (
 func toProtoWeeklyMealPlan(plan *models.WeeklyMealPlan) *apipb.WeeklyMealPlan {
 	pb := &apipb.WeeklyMealPlan{Days: make([]*apipb.PlanDay, len(plan.Days))}
 	for i, d := range plan.Days {
-		pb.Days[i] = &apipb.PlanDay{Meal: d.Meal, DayIndex: int32(d.DayIndex), MealType: d.MealType}
+		pb.Days[i] = &apipb.PlanDay{Meal: d.Meal, DayIndex: d.DayIndex, MealType: d.MealType}
 	}
 	pb.ShoppingList = make([]*apipb.ShoppingListItem, len(plan.ShoppingList))
 	for i, item := range plan.ShoppingList {
@@ -49,7 +49,10 @@ func attachShoppingList(plan *models.WeeklyMealPlan) {
 	}
 	items, err := buildShoppingList(mealIDs)
 	if err == nil {
-		plan.ShoppingList = items
+		plan.ShoppingList = make([]*models.ShoppingListItem, len(items))
+		for i := range items {
+			plan.ShoppingList[i] = &items[i]
+		}
 	}
 }
 

--- a/backend/handlers/meals_test.go
+++ b/backend/handlers/meals_test.go
@@ -873,7 +873,7 @@ func TestRemoveMealHandler(t *testing.T) {
 	helper := setupTest(t)
 
 	plan := models.WeeklyMealPlan{
-		Days: []models.PlanDay{{DayIndex: 0, MealType: "breakfast", Meal: &models.Meal{Id: 1, Name: "Egg"}}},
+		Days: []*models.PlanDay{{DayIndex: 0, MealType: "breakfast", Meal: &models.Meal{Id: 1, Name: "Egg"}}},
 	}
 	checkpointStruct := map[string]interface{}{
 		"channel_values": map[string]interface{}{

--- a/backend/handlers/workflows.go
+++ b/backend/handlers/workflows.go
@@ -39,7 +39,7 @@ func GetWorkflowState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get meal plan entries
-	entries, err := Services.MealPlanService.GetMealPlanItems(plan.ID)
+	entries, err := Services.MealPlanService.GetMealPlanItems(int(plan.GetId()))
 	if err != nil {
 		http.Error(w, "failed to get meal plan items: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/handlers/workflows_test.go
+++ b/backend/handlers/workflows_test.go
@@ -234,19 +234,19 @@ func TestGetWorkflowStateReturnsShoppingList(t *testing.T) {
 	Services = svc
 
 	threadID := "thread123"
-	plan := &models.MealPlanIdentifier{ID: 1, ThreadID: threadID}
+	plan := &models.MealPlanIdentifier{Id: 1, ThreadId: threadID}
 	entries := []models.MealPlanEntry{
-		{DayOfWeek: 0, MealType: "breakfast", Meal: map[string]interface{}{"id": plan.ID, "name": "Test Meal"}},
+		{DayOfWeek: 0, MealType: "breakfast", Meal: &models.Meal{Id: plan.Id, Name: "Test Meal"}},
 	}
 	shoppingItems := []models.ShoppingListItem{
 		{Ingredient: "Eggs", Quantity: "12"},
 	}
 	messages := []models.ChatMessage{
-		{Sender: "user", Text: "Hello"},
+		{Sender: "user", Content: "Hello"},
 	}
 
 	stubMealPlanSvc.On("GetLatestMealPlan", threadID).Return(plan, nil)
-	stubMealPlanSvc.On("GetMealPlanItems", plan.ID).Return(entries, nil)
+	stubMealPlanSvc.On("GetMealPlanItems", int(plan.Id)).Return(entries, nil)
 	mockShoppingListSvc.On("BuildShoppingList", []int{}).Return(shoppingItems, nil)
 	stubMessageSvc.On("GetMessages", threadID).Return(messages, nil)
 

--- a/backend/models/agent.go
+++ b/backend/models/agent.go
@@ -2,16 +2,16 @@ package models
 
 import (
 	"errors"
+
+	apipb "mealplanner/generated/go"
 )
 
 // AgentStartRequest represents a request to start a workflow
 // Example JSON: {"participants":["brad","shannon"],"workflowType":"meal_planning"}
-type AgentStartRequest struct {
-	Participants []string `json:"participants"`
-	WorkflowType string   `json:"workflowType"`
-}
+// AgentStartRequest aliases the protobuf message
+type AgentStartRequest = apipb.AgentStartRequest
 
-func (r *AgentStartRequest) Validate() error {
+func ValidateAgentStartRequest(r *apipb.AgentStartRequest) error {
 	if len(r.Participants) == 0 {
 		return errors.New("participants required")
 	}
@@ -23,14 +23,11 @@ func (r *AgentStartRequest) Validate() error {
 
 // AgentFeedbackRequest represents feedback for a workflow
 // Example JSON: {"threadId":"uuid","message":"text","from":"brad"}
-type AgentFeedbackRequest struct {
-	ThreadID string `json:"threadId"`
-	Message  string `json:"message"`
-	From     string `json:"from"`
-}
+// AgentFeedbackRequest aliases the protobuf message
+type AgentFeedbackRequest = apipb.AgentFeedbackRequest
 
-func (r *AgentFeedbackRequest) Validate() error {
-	if r.ThreadID == "" {
+func ValidateAgentFeedbackRequest(r *apipb.AgentFeedbackRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	if r.Message == "" {
@@ -44,13 +41,11 @@ func (r *AgentFeedbackRequest) Validate() error {
 
 // AgentResumeRequest represents a resume request
 // Example JSON: {"threadId":"uuid","interactive":false}
-type AgentResumeRequest struct {
-	ThreadID    string `json:"threadId"`
-	Interactive bool   `json:"interactive"`
-}
+// AgentResumeRequest aliases the protobuf message
+type AgentResumeRequest = apipb.AgentResumeRequest
 
-func (r *AgentResumeRequest) Validate() error {
-	if r.ThreadID == "" {
+func ValidateAgentResumeRequest(r *apipb.AgentResumeRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	return nil
@@ -58,16 +53,12 @@ func (r *AgentResumeRequest) Validate() error {
 
 // AgentMessageRequest represents a combined feedback and resume request
 // Example JSON: {"threadId":"uuid","message":"text","from":"user","interactive":false}
-type AgentMessageRequest struct {
-	ThreadID    string `json:"threadId"`
-	Message     string `json:"message"`
-	From        string `json:"from"`
-	Interactive bool   `json:"interactive"`
-}
+// AgentMessageRequest aliases the protobuf message
+type AgentMessageRequest = apipb.AgentMessageRequest
 
 // Validate ensures AgentMessageRequest has required fields
-func (r *AgentMessageRequest) Validate() error {
-	if r.ThreadID == "" {
+func ValidateAgentMessageRequest(r *apipb.AgentMessageRequest) error {
+	if r.ThreadId == "" {
 		return errors.New("threadId required")
 	}
 	if r.Message == "" {
@@ -85,20 +76,10 @@ func (r *AgentMessageRequest) Validate() error {
 // CurrentStep is the agent's workflow step
 // MealPlan or other data may be embedded in Raw
 
-type AgentResponse struct {
-	Success      bool        `json:"success"`
-	Message      string      `json:"message,omitempty"`
-	ThreadID     string      `json:"threadId,omitempty"`
-	CurrentStep  string      `json:"currentStep,omitempty"`
-	InitialState interface{} `json:"initialState,omitempty"`
-	Raw          interface{} `json:"raw,omitempty"`
-}
+// AgentResponse aliases the protobuf message
+type AgentResponse = apipb.AgentResponse
 
 // WorkflowStatus represents high level workflow info
 // {"threadId":"uuid","workflowType":"meal_planning","currentStep":"step","participants":["brad"]}
-type WorkflowStatus struct {
-	ThreadID     string   `json:"threadId"`
-	WorkflowType string   `json:"workflowType"`
-	CurrentStep  string   `json:"currentStep"`
-	Participants []string `json:"participants"`
-}
+// WorkflowStatus aliases the protobuf message
+type WorkflowStatus = apipb.WorkflowStatus

--- a/backend/models/agent_test.go
+++ b/backend/models/agent_test.go
@@ -4,49 +4,49 @@ import "testing"
 
 func TestAgentStartRequestValidate(t *testing.T) {
 	req := AgentStartRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentStartRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
 	req.Participants = []string{"a"}
 	req.WorkflowType = "meal_planning"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentStartRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentFeedbackRequestValidate(t *testing.T) {
 	req := AgentFeedbackRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentFeedbackRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
+	req.ThreadId = "id"
 	req.Message = "msg"
 	req.From = "brad"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentFeedbackRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentResumeRequestValidate(t *testing.T) {
 	req := AgentResumeRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentResumeRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
-	if err := req.Validate(); err != nil {
+	req.ThreadId = "id"
+	if err := ValidateAgentResumeRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestAgentMessageRequestValidate(t *testing.T) {
 	req := AgentMessageRequest{}
-	if err := req.Validate(); err == nil {
+	if err := ValidateAgentMessageRequest(&req); err == nil {
 		t.Error("expected error for empty request")
 	}
-	req.ThreadID = "id"
+	req.ThreadId = "id"
 	req.Message = "hello"
 	req.From = "brad"
-	if err := req.Validate(); err != nil {
+	if err := ValidateAgentMessageRequest(&req); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/backend/models/checkpoint.go
+++ b/backend/models/checkpoint.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	apipb "mealplanner/generated/go"
 )
 
-// ChatMessage represents a chat message in a workflow
-type ChatMessage struct {
-	Sender string `json:"sender"`
-	Text   string `json:"text"`
-}
+// ChatMessage aliases the protobuf message
+type ChatMessage = apipb.Message
 
 // GetWorkflowCheckpoint retrieves the latest checkpoint data for a thread
 func GetWorkflowCheckpoint(db *sql.DB, threadID string) ([]byte, string, error) {
@@ -91,7 +90,7 @@ func GetMessages(db *sql.DB, threadID string) ([]ChatMessage, error) {
 		if vm, ok := v.(map[string]interface{}); ok {
 			sender, _ := vm["sender"].(string)
 			text, _ := vm["text"].(string)
-			msgs = append(msgs, ChatMessage{Sender: sender, Text: text})
+			msgs = append(msgs, ChatMessage{Sender: sender, Content: text})
 		}
 	}
 	return msgs, nil
@@ -103,5 +102,5 @@ func AddMessage(db *sql.DB, threadID, sender, message string) (ChatMessage, erro
 	if err != nil {
 		return ChatMessage{}, err
 	}
-	return ChatMessage{Sender: sender, Text: message}, nil
+	return ChatMessage{Sender: sender, Content: message}, nil
 }

--- a/backend/models/mealplan.go
+++ b/backend/models/mealplan.go
@@ -8,26 +8,18 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+	apipb "mealplanner/generated/go"
 )
 
-// PlanDay represents a single meal slot in the plan using the array based
-// representation preferred by the agent workflow.
-type PlanDay struct {
-	Meal     *Meal  `json:"meal"`
-	DayIndex int    `json:"dayIndex"` // 0=Monday .. 6=Sunday
-	MealType string `json:"mealType"` // breakfast, lunch or dinner
-}
+// PlanDay aliases the protobuf message
+type PlanDay = apipb.PlanDay
 
-// WeeklyMealPlan represents a week's worth of meals as a flat array of PlanDay
-// entries.  This mirrors the structure produced and consumed by the agent.
-type WeeklyMealPlan struct {
-	Days         []PlanDay          `json:"days"`
-	ShoppingList []ShoppingListItem `json:"shoppingList,omitempty"`
-}
+// WeeklyMealPlan aliases the protobuf message
+type WeeklyMealPlan = apipb.WeeklyMealPlan
 
 // GenerateWeeklyMealPlan generates a weekly plan with breakfast, lunch, and dinner.
 func GenerateWeeklyMealPlan(db *sql.DB) (*WeeklyMealPlan, error) {
-	plan := &WeeklyMealPlan{Days: make([]PlanDay, 0, 21)}
+	plan := &WeeklyMealPlan{Days: make([]*PlanDay, 0, 21)}
 	redMeatUsed := false
 	threeWeeksAgo := time.Now().AddDate(0, 0, -21)
 
@@ -58,7 +50,7 @@ func GenerateWeeklyMealPlan(db *sql.DB) (*WeeklyMealPlan, error) {
 			if mealType == "dinner" && meal != nil && meal.GetHasRedMeat() {
 				redMeatUsed = true
 			}
-			plan.Days = append(plan.Days, PlanDay{Meal: meal, DayIndex: i, MealType: mealType})
+			plan.Days = append(plan.Days, &PlanDay{Meal: meal, DayIndex: int32(i), MealType: mealType})
 		}
 	}
 
@@ -129,7 +121,7 @@ func pickMeal(db *sql.DB, minEffort, maxEffort int, excludeRedMeat bool, cutoff 
 
 // GetLastPlannedMeals retrieves the most recently planned meals to reconstruct the last meal plan
 func GetLastPlannedMeals(db *sql.DB) (*WeeklyMealPlan, error) {
-	plan := &WeeklyMealPlan{Days: make([]PlanDay, 0, 21)}
+	plan := &WeeklyMealPlan{Days: make([]*PlanDay, 0, 21)}
 	// Friday is now included for breakfast and lunch, but dinner is always "Eating out"
 	weekdays := DaysOfTheWeek
 	numMealsNeeded := len(weekdays)
@@ -156,9 +148,9 @@ func GetLastPlannedMeals(db *sql.DB) (*WeeklyMealPlan, error) {
 
 	for i := range weekdays {
 		plan.Days = append(plan.Days,
-			PlanDay{DayIndex: i, MealType: "breakfast", Meal: lastBreakfasts[i]},
-			PlanDay{DayIndex: i, MealType: "lunch", Meal: lastLunches[i]},
-			PlanDay{DayIndex: i, MealType: "dinner", Meal: lastDinners[i]},
+			&PlanDay{DayIndex: int32(i), MealType: "breakfast", Meal: lastBreakfasts[i]},
+			&PlanDay{DayIndex: int32(i), MealType: "lunch", Meal: lastLunches[i]},
+			&PlanDay{DayIndex: int32(i), MealType: "dinner", Meal: lastDinners[i]},
 		)
 	}
 
@@ -232,10 +224,11 @@ func MealPlanToICS(plan *WeeklyMealPlan, monday time.Time) string {
 	// Build lookup maps for quick access
 	mealsByDay := make(map[int]map[string]*Meal)
 	for _, pd := range plan.Days {
-		if _, ok := mealsByDay[pd.DayIndex]; !ok {
-			mealsByDay[pd.DayIndex] = make(map[string]*Meal)
+		idx := int(pd.DayIndex)
+		if _, ok := mealsByDay[idx]; !ok {
+			mealsByDay[idx] = make(map[string]*Meal)
 		}
-		mealsByDay[pd.DayIndex][strings.Title(pd.MealType)] = pd.Meal
+		mealsByDay[idx][strings.Title(pd.MealType)] = pd.Meal
 	}
 
 	var b strings.Builder
@@ -307,8 +300,8 @@ func RemoveMealFromPlan(plan *WeeklyMealPlan, dayIndex int, mealType string) err
 	}
 
 	for i := range plan.Days {
-		d := &plan.Days[i]
-		if d.DayIndex == dayIndex && d.MealType == mealType {
+		d := plan.Days[i]
+		if int(d.DayIndex) == dayIndex && d.MealType == mealType {
 			if d.Meal == nil {
 				return errors.New("meal already empty")
 			}

--- a/backend/models/mealplan_ics_test.go
+++ b/backend/models/mealplan_ics_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMealPlanToICS(t *testing.T) {
 	plan := &WeeklyMealPlan{
-		Days: []PlanDay{
+		Days: []*PlanDay{
 			{DayIndex: 0, MealType: "dinner", Meal: &Meal{Id: 1, Name: "Test Meal", Url: "https://example.com"}},
 			{DayIndex: 1, MealType: "dinner", Meal: &Meal{Id: 2, Name: "Another Meal"}},
 		},

--- a/backend/models/mealplan_sql.go
+++ b/backend/models/mealplan_sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"time"
+
 	apipb "mealplanner/generated/go"
 )
 
@@ -11,12 +12,8 @@ import (
 type MealPlanEntry = apipb.MealPlanEntry
 
 // MealPlanIdentifier represents a persisted meal plan
-type MealPlanIdentifier struct {
-	ID        int       `json:"id"`
-	ThreadID  string    `json:"thread_id"`
-	Version   int       `json:"version"`
-	CreatedAt time.Time `json:"created_at"`
-}
+// MealPlanIdentifier aliases the protobuf message
+type MealPlanIdentifier = apipb.MealPlanIdentifier
 
 // SaveMealPlan persists a meal plan and its items
 func SaveMealPlan(db *sql.DB, threadID string, version int, entries []MealPlanEntry) (*MealPlanIdentifier, error) {
@@ -46,7 +43,12 @@ func SaveMealPlan(db *sql.DB, threadID string, version int, entries []MealPlanEn
 			return nil, err
 		}
 	}
-	return &MealPlanIdentifier{ID: id, ThreadID: tid, Version: ver, CreatedAt: createdAt}, nil
+	return &MealPlanIdentifier{
+		Id:        int32(id),
+		ThreadId:  tid,
+		Version:   int32(ver),
+		CreatedAt: createdAt.Format(time.RFC3339),
+	}, nil
 }
 
 // GetLatestMealPlan retrieves the latest meal plan identifier for a thread
@@ -57,12 +59,20 @@ func GetLatestMealPlan(db *sql.DB, threadID string) (*MealPlanIdentifier, error)
 	WHERE thread_id = $1
 	ORDER BY version DESC
 	LIMIT 1`
-	var m MealPlanIdentifier
-	err := db.QueryRow(query, threadID).Scan(&m.ID, &m.ThreadID, &m.Version, &m.CreatedAt)
+	var id int
+	var tid string
+	var ver int
+	var createdAt time.Time
+	err := db.QueryRow(query, threadID).Scan(&id, &tid, &ver, &createdAt)
 	if err != nil {
 		return nil, err
 	}
-	return &m, nil
+	return &MealPlanIdentifier{
+		Id:        int32(id),
+		ThreadId:  tid,
+		Version:   int32(ver),
+		CreatedAt: createdAt.Format(time.RFC3339),
+	}, nil
 }
 
 // GetMealPlanItems retrieves items for a given meal plan
@@ -84,7 +94,7 @@ func GetMealPlanItems(db *sql.DB, mealPlanID int) ([]MealPlanEntry, error) {
 		if err := rows.Scan(&e.DayOfWeek, &e.MealType, &mealJSON); err != nil {
 			return nil, err
 		}
-		
+
 		// Unmarshal the JSON into a Meal object
 		var meal Meal
 		if err := json.Unmarshal(mealJSON, &meal); err != nil {

--- a/backend/models/mealplan_sql_test.go
+++ b/backend/models/mealplan_sql_test.go
@@ -17,7 +17,7 @@ func TestSaveMealPlan_Success(t *testing.T) {
 
 	threadID := "thread1"
 	version := 1
-	testMeal := map[string]interface{}{"id": 101, "name": "Test Meal"}
+	testMeal := &Meal{Id: 101, Name: "Test Meal"}
 	entries := []MealPlanEntry{
 		{DayOfWeek: 0, MealType: "breakfast", Meal: testMeal},
 	}
@@ -36,9 +36,9 @@ func TestSaveMealPlan_Success(t *testing.T) {
 
 	id, err := SaveMealPlan(db, threadID, version, entries)
 	assert.NoError(t, err)
-	assert.Equal(t, 42, id.ID)
-	assert.Equal(t, threadID, id.ThreadID)
-	assert.Equal(t, version, id.Version)
+	assert.Equal(t, int32(42), id.Id)
+	assert.Equal(t, threadID, id.ThreadId)
+	assert.Equal(t, int32(version), id.Version)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -57,9 +57,9 @@ func TestGetLatestMealPlan_Success(t *testing.T) {
 
 	mp, err := GetLatestMealPlan(db, threadID)
 	assert.NoError(t, err)
-	assert.Equal(t, 43, mp.ID)
-	assert.Equal(t, threadID, mp.ThreadID)
-	assert.Equal(t, 2, mp.Version)
+	assert.Equal(t, int32(43), mp.Id)
+	assert.Equal(t, threadID, mp.ThreadId)
+	assert.Equal(t, int32(2), mp.Version)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -80,9 +80,10 @@ func TestGetMealPlanItems_Success(t *testing.T) {
 	items, err := GetMealPlanItems(db, mealPlanID)
 	assert.NoError(t, err)
 	assert.Len(t, items, 1)
-	assert.Equal(t, 1, items[0].DayOfWeek)
+	assert.Equal(t, int32(1), items[0].DayOfWeek)
 	assert.Equal(t, "lunch", items[0].MealType)
-	assert.Equal(t, testMealJSON, items[0].Meal)
+	assert.Equal(t, int32(202), items[0].Meal.Id)
+	assert.Equal(t, "Test Lunch Meal", items[0].Meal.Name)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/models/mealplan_test.go
+++ b/backend/models/mealplan_test.go
@@ -91,7 +91,7 @@ func TestPickMeal(t *testing.T) {
 // It returns the meal or nil if not found.
 func findMeal(plan *WeeklyMealPlan, dayIndex int, mealType string) *Meal {
 	for _, d := range plan.Days {
-		if d.DayIndex == dayIndex && d.MealType == mealType {
+		if int(d.DayIndex) == dayIndex && d.MealType == mealType {
 			return d.Meal
 		}
 	}
@@ -353,7 +353,7 @@ func TestGetLastPlannedMeals(t *testing.T) {
 
 func TestRemoveMealFromPlan(t *testing.T) {
 	plan := &WeeklyMealPlan{
-		Days: []PlanDay{
+		Days: []*PlanDay{
 			{DayIndex: 0, MealType: "breakfast", Meal: &Meal{Id: 1, Name: "A"}},
 			{DayIndex: 1, MealType: "lunch", Meal: &Meal{Id: 2, Name: "B"}},
 			{DayIndex: 2, MealType: "dinner", Meal: &Meal{Id: 3, Name: "C"}},
@@ -389,7 +389,7 @@ func TestRemoveMealFromPlan(t *testing.T) {
 
 func TestBuildShoppingListFromPlan(t *testing.T) {
 	plan := &WeeklyMealPlan{
-		Days: []PlanDay{
+		Days: []*PlanDay{
 			{DayIndex: 0, MealType: "dinner", Meal: &Meal{Id: 1, Ingredients: []*Ingredient{{Name: "Eggs", Quantity: 1, Unit: ""}}}},
 			{DayIndex: 1, MealType: "dinner", Meal: &Meal{Id: 2, Ingredients: []*Ingredient{{Name: "Milk", Quantity: 2, Unit: "cups"}}}},
 		},

--- a/backend/models/shoppinglist.go
+++ b/backend/models/shoppinglist.go
@@ -4,16 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	apipb "mealplanner/generated/go"
 )
 
-// ShoppingListItem represents a single entry in the generated shopping list.
-// Ingredient is the name of the item and Quantity is a human readable amount
-// (e.g. "1 cup"). Category is optional and may be empty.
-type ShoppingListItem struct {
-	Ingredient string `json:"ingredient"`
-	Quantity   string `json:"quantity"`
-	Category   string `json:"category,omitempty"`
-}
+// ShoppingListItem aliases the protobuf message
+type ShoppingListItem = apipb.ShoppingListItem
 
 // GenerateShoppingListFromMeals aggregates the ingredients needed for the given meals.
 // It returns a sorted slice of unique ingredients with aggregated quantities.

--- a/backend/services/meal_plan_service.go
+++ b/backend/services/meal_plan_service.go
@@ -79,11 +79,11 @@ func (s *mealPlanService) PopulateMealDetails(plan *models.WeeklyMealPlan) (*mod
 
 	// Create a copy of the plan with populated meal details
 	populatedPlan := *plan
-	populatedPlan.Days = make([]models.PlanDay, len(plan.Days))
+	populatedPlan.Days = make([]*models.PlanDay, len(plan.Days))
 	copy(populatedPlan.Days, plan.Days)
 
 	for i := range populatedPlan.Days {
-		d := &populatedPlan.Days[i]
+		d := populatedPlan.Days[i]
 		if d.Meal != nil {
 			if fullMeal, ok := mealMap[int(d.Meal.GetId())]; ok {
 				d.Meal = fullMeal

--- a/backend/services/message_service_sql.go
+++ b/backend/services/message_service_sql.go
@@ -22,7 +22,7 @@ func (s *sqlMessageService) GetMessages(threadID string) ([]models.ChatMessage, 
 	}
 	var out []models.ChatMessage
 	for _, m := range msgs {
-		out = append(out, models.ChatMessage{Sender: m.Sender, Text: m.Content})
+		out = append(out, models.ChatMessage{Sender: m.Sender, Content: m.Content})
 	}
 	return out, nil
 }
@@ -33,7 +33,7 @@ func (s *sqlMessageService) AddMessage(threadID, sender, message string) (models
 	if err != nil {
 		return models.ChatMessage{}, err
 	}
-	return models.ChatMessage{Sender: m.Sender, Text: m.Content}, nil
+	return models.ChatMessage{Sender: m.Sender, Content: m.Content}, nil
 }
 
 // UpdateWorkflowCheckpointWithMessage is unsupported in SQLMessageService


### PR DESCRIPTION
## Summary
- replace custom structs with protobuf aliases
- adjust handlers and services to use proto types
- update tests for new types and fields

## Testing
- `go test ./handlers ./models`
- `yarn test` *(fails: frontend and agent tests require additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_686d32bfc4c4832493e64ec60c68518c