### PR TITLE
Move agent workflow endpoints to agent service

### DIFF
--- a/agent-service/main.ts
+++ b/agent-service/main.ts
@@ -17,6 +17,7 @@ import {
     ResumeWorkflowRequest,
     ResumeWorkflowResponse
 } from '@mealplanner/generated/agent_pb';
+import * as apipb from '@mealplanner/generated/api_pb';
 
 // Initialize agent instance
 let agentInstance: LangGraphAgent | null = null;
@@ -221,6 +222,70 @@ function resumeWorkflow(call: grpc.ServerUnaryCall<ResumeWorkflowRequest, Resume
     })();
 }
 
+// StartAgentWorkflow implementation - wraps PlanStart for API gateway
+function startAgentWorkflow(call: grpc.ServerUnaryCall<apipb.StartAgentWorkflowRequest, apipb.StartAgentWorkflowResponse>, callback: grpc.sendUnaryData<apipb.StartAgentWorkflowResponse>): void {
+    (async () => {
+        try {
+            const request = call.request.request;
+            if (!request) {
+                return callback(new Error('request is required'));
+            }
+            if (!request.participants || request.participants.length === 0) {
+                return callback(new Error('participants required'));
+            }
+
+            const agent = await initializeAgent();
+            const threadId = await agent.startWorkflow(WorkflowType.MEAL_PLANNING, request.participants);
+            const state = await agent.getWorkflowState(threadId);
+
+            const resp = new apipb.AgentResponse({
+                success: true,
+                message: 'Workflow started',
+                threadId,
+                currentStep: state.currentStep,
+                initialState: state.toJsonString(),
+            });
+
+            callback(null, new apipb.StartAgentWorkflowResponse({ response: resp }));
+        } catch (error) {
+            const errMsg = error instanceof Error ? error.message : String(error);
+            callback(new Error(`Error starting workflow: ${errMsg}`));
+        }
+    })();
+}
+
+// MessageAgent implementation - wraps PlanFeedback and ResumeWorkflow
+function messageAgent(call: grpc.ServerUnaryCall<apipb.MessageAgentRequest, apipb.MessageAgentResponse>, callback: grpc.sendUnaryData<apipb.MessageAgentResponse>): void {
+    (async () => {
+        try {
+            const request = call.request.request;
+            if (!request) {
+                return callback(new Error('request is required'));
+            }
+            const { threadId, message, from } = request;
+            if (!threadId) return callback(new Error('threadId required'));
+            if (!message) return callback(new Error('message required'));
+            if (!from) return callback(new Error('from required'));
+
+            const agent = await initializeAgent();
+            const repo = new MessageRepository();
+            await repo.addMessage(threadId, from, message);
+
+            const result = await agent.resumeWorkflow(threadId, {});
+            const resp = new apipb.AgentResponse({
+                success: result.success,
+                message: result.message || '',
+                threadId,
+                currentStep: result.currentStep || '',
+            });
+            callback(null, new apipb.MessageAgentResponse({ response: resp }));
+        } catch (error) {
+            const errMsg = error instanceof Error ? error.message : String(error);
+            callback(new Error(`Error messaging agent: ${errMsg}`));
+        }
+    })();
+}
+
 // Load the protobuf definition
 const PROTO_PATH = path.join(__dirname, '../../proto/agent.proto');
 const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
@@ -261,6 +326,8 @@ function startServer(): void {
         planFeedback,
         planFinalize,
         resumeWorkflow,
+        startAgentWorkflow,
+        messageAgent,
     });
 
     // Bind and start the server

--- a/api-gateway/main.go
+++ b/api-gateway/main.go
@@ -23,6 +23,7 @@ import (
 
 	logger "logging-service/client/go"
 	apipb "mealplanner/generated/go"
+	agentpb "mealplanner/generated/go/agent"
 )
 
 // @title Meal Planner API Gateway
@@ -228,12 +229,13 @@ var mealPlannerClient apipb.MealPlannerAPIClient
 
 // Gateway represents the API Gateway server
 type Gateway struct {
-	client apipb.MealPlannerAPIClient
+	backend apipb.MealPlannerAPIClient
+	agent   agentpb.AgentServiceClient
 }
 
 // NewGateway creates a new Gateway instance
-func NewGateway(client apipb.MealPlannerAPIClient) *Gateway {
-	return &Gateway{client: client}
+func NewGateway(backend apipb.MealPlannerAPIClient, agent agentpb.AgentServiceClient) *Gateway {
+	return &Gateway{backend: backend, agent: agent}
 }
 
 // httpStatusFromGRPC converts gRPC status codes to HTTP status codes
@@ -345,7 +347,20 @@ func main() {
 	defer conn.Close()
 
 	mealPlannerClient = apipb.NewMealPlannerAPIClient(conn)
-	gw := NewGateway(mealPlannerClient)
+
+	// Connect to agent gRPC service
+	agentAddr := os.Getenv("AGENT_GRPC_ADDR")
+	if agentAddr == "" {
+		agentAddr = "localhost:50053"
+	}
+	agentConn, err := grpc.NewClient(agentAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatal("Failed to connect to agent gRPC server:", err)
+	}
+	defer agentConn.Close()
+
+	agentClient = agentpb.NewAgentServiceClient(agentConn)
+	gw := NewGateway(mealPlannerClient, agentClient)
 
 	// Set up HTTP routes with Chi router
 	r := chi.NewRouter()
@@ -446,7 +461,7 @@ func main() {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /health [get]
 func (gw *Gateway) healthCheck(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.HealthCheck(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.HealthCheck(r.Context(), &emptypb.Empty{})
 	writeJSONResponse(w, resp, err)
 }
 
@@ -459,7 +474,7 @@ func (gw *Gateway) healthCheck(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /reconnect [post]
 func (gw *Gateway) reconnect(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.Reconnect(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.Reconnect(r.Context(), &emptypb.Empty{})
 	writeJSONResponse(w, resp, err)
 }
 
@@ -474,7 +489,7 @@ func (gw *Gateway) reconnect(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /mealplan [get]
 func (gw *Gateway) getMealPlan(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.GetMealPlan(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.GetMealPlan(r.Context(), &emptypb.Empty{})
 	writeJSONResponse(w, resp, err)
 }
 
@@ -515,7 +530,7 @@ func (gw *Gateway) saveMealPlan(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /mealplan/generate [post]
 func (gw *Gateway) generateMealPlan(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.GenerateMealPlan(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.GenerateMealPlan(r.Context(), &emptypb.Empty{})
 	writeJSONResponse(w, resp, err)
 }
 
@@ -542,7 +557,7 @@ func (gw *Gateway) finalizeMealPlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.FinalizeMealPlan(r.Context(), &req)
+	resp, err := gw.backend.FinalizeMealPlan(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -555,7 +570,7 @@ func (gw *Gateway) finalizeMealPlan(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /mealplan/ics [get]
 func (gw *Gateway) getMealPlanICS(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.GetMealPlanICS(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.GetMealPlanICS(r.Context(), &emptypb.Empty{})
 	if err != nil {
 		status := httpStatusFromGRPC(err)
 		http.Error(w, err.Error(), status)
@@ -592,7 +607,7 @@ func (gw *Gateway) getShoppingList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.GetShoppingList(r.Context(), &req)
+	resp, err := gw.backend.GetShoppingList(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -612,7 +627,7 @@ func (gw *Gateway) getAllMeals(w http.ResponseWriter, r *http.Request) {
 		Type: r.URL.Query().Get("type"),
 	}
 
-	resp, err := gw.client.GetAllMeals(r.Context(), req)
+	resp, err := gw.backend.GetAllMeals(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -639,7 +654,7 @@ func (gw *Gateway) createMeal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.CreateMeal(r.Context(), &req)
+	resp, err := gw.backend.CreateMeal(r.Context(), &req)
 	if err == nil {
 		w.WriteHeader(http.StatusCreated)
 	}
@@ -669,7 +684,7 @@ func (gw *Gateway) swapMeal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.SwapMeal(r.Context(), &req)
+	resp, err := gw.backend.SwapMeal(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -696,7 +711,7 @@ func (gw *Gateway) removeMeal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.RemoveMeal(r.Context(), &req)
+	resp, err := gw.backend.RemoveMeal(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -746,7 +761,7 @@ func (gw *Gateway) updateMealIngredient(w http.ResponseWriter, r *http.Request) 
 		Ingredient:   &ingredient,
 	}
 
-	resp, err := gw.client.UpdateMealIngredient(r.Context(), req)
+	resp, err := gw.backend.UpdateMealIngredient(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -782,7 +797,7 @@ func (gw *Gateway) deleteMealIngredient(w http.ResponseWriter, r *http.Request) 
 		IngredientId: int32(ingredientId),
 	}
 
-	resp, err := gw.client.DeleteMealIngredient(r.Context(), req)
+	resp, err := gw.backend.DeleteMealIngredient(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -809,7 +824,7 @@ func (gw *Gateway) deleteMeal(w http.ResponseWriter, r *http.Request) {
 		MealId: int32(mealId),
 	}
 
-	resp, err := gw.client.DeleteMeal(r.Context(), req)
+	resp, err := gw.backend.DeleteMeal(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -836,7 +851,7 @@ func (gw *Gateway) replaceMeal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.ReplaceMeal(r.Context(), &req)
+	resp, err := gw.backend.ReplaceMeal(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -864,7 +879,7 @@ func (gw *Gateway) getSteps(w http.ResponseWriter, r *http.Request) {
 		MealId: int32(mealId),
 	}
 
-	resp, err := gw.client.GetSteps(r.Context(), req)
+	resp, err := gw.backend.GetSteps(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -905,7 +920,7 @@ func (gw *Gateway) addStep(w http.ResponseWriter, r *http.Request) {
 		Step:   &step,
 	}
 
-	resp, err := gw.client.AddStep(r.Context(), req)
+	resp, err := gw.backend.AddStep(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -948,7 +963,7 @@ func (gw *Gateway) addBulkSteps(w http.ResponseWriter, r *http.Request) {
 		Instructions: reqBody.Instructions,
 	}
 
-	resp, err := gw.client.AddBulkSteps(r.Context(), req)
+	resp, err := gw.backend.AddBulkSteps(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -998,7 +1013,7 @@ func (gw *Gateway) updateStep(w http.ResponseWriter, r *http.Request) {
 		Step:   &step,
 	}
 
-	resp, err := gw.client.UpdateStep(r.Context(), req)
+	resp, err := gw.backend.UpdateStep(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1034,7 +1049,7 @@ func (gw *Gateway) deleteStep(w http.ResponseWriter, r *http.Request) {
 		StepId: int32(stepId),
 	}
 
-	resp, err := gw.client.DeleteStep(r.Context(), req)
+	resp, err := gw.backend.DeleteStep(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1077,7 +1092,7 @@ func (gw *Gateway) reorderSteps(w http.ResponseWriter, r *http.Request) {
 		StepIds: reqBody.StepIds,
 	}
 
-	resp, err := gw.client.ReorderSteps(r.Context(), req)
+	resp, err := gw.backend.ReorderSteps(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1104,7 +1119,7 @@ func (gw *Gateway) deleteAllSteps(w http.ResponseWriter, r *http.Request) {
 		MealId: int32(mealId),
 	}
 
-	resp, err := gw.client.DeleteAllSteps(r.Context(), req)
+	resp, err := gw.backend.DeleteAllSteps(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1134,7 +1149,7 @@ func (gw *Gateway) startAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		req := &apipb.StartAgentWorkflowRequest{
 			Request: &agentReq,
 		}
-		resp, err := gw.client.StartAgentWorkflow(r.Context(), req)
+		resp, err := gw.agent.StartAgentWorkflow(r.Context(), req)
 		writeJSONResponse(w, resp, err)
 		return
 	}
@@ -1146,7 +1161,7 @@ func (gw *Gateway) startAgentWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.StartAgentWorkflow(r.Context(), &req)
+	resp, err := gw.agent.StartAgentWorkflow(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1174,7 +1189,7 @@ func (gw *Gateway) messageAgent(w http.ResponseWriter, r *http.Request) {
 		req := &apipb.MessageAgentRequest{
 			Request: &agentReq,
 		}
-		resp, err := gw.client.MessageAgent(r.Context(), req)
+		resp, err := gw.agent.MessageAgent(r.Context(), req)
 		writeJSONResponse(w, resp, err)
 		return
 	}
@@ -1186,7 +1201,7 @@ func (gw *Gateway) messageAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.MessageAgent(r.Context(), &req)
+	resp, err := gw.agent.MessageAgent(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1207,7 +1222,7 @@ func (gw *Gateway) getWorkflowStatus(w http.ResponseWriter, r *http.Request) {
 		ThreadId: threadId,
 	}
 
-	resp, err := gw.client.GetWorkflowStatus(r.Context(), req)
+	resp, err := gw.backend.GetWorkflowStatus(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1220,7 +1235,7 @@ func (gw *Gateway) getWorkflowStatus(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /agent/workflows [get]
 func (gw *Gateway) listWorkflows(w http.ResponseWriter, r *http.Request) {
-	resp, err := gw.client.ListWorkflows(r.Context(), &emptypb.Empty{})
+	resp, err := gw.backend.ListWorkflows(r.Context(), &emptypb.Empty{})
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1241,7 +1256,7 @@ func (gw *Gateway) cancelWorkflow(w http.ResponseWriter, r *http.Request) {
 		ThreadId: threadId,
 	}
 
-	resp, err := gw.client.CancelWorkflow(r.Context(), req)
+	resp, err := gw.backend.CancelWorkflow(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1263,7 +1278,7 @@ func (gw *Gateway) getWorkflowState(w http.ResponseWriter, r *http.Request) {
 		ThreadId: threadId,
 	}
 
-	resp, err := gw.client.GetWorkflowState(r.Context(), req)
+	resp, err := gw.backend.GetWorkflowState(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1284,7 +1299,7 @@ func (gw *Gateway) abandonWorkflow(w http.ResponseWriter, r *http.Request) {
 		ThreadId: threadId,
 	}
 
-	resp, err := gw.client.AbandonWorkflow(r.Context(), req)
+	resp, err := gw.backend.AbandonWorkflow(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1323,7 +1338,7 @@ func (gw *Gateway) addMessage(w http.ResponseWriter, r *http.Request) {
 		Message:  reqBody.Message,
 	}
 
-	resp, err := gw.client.AddMessage(r.Context(), req)
+	resp, err := gw.backend.AddMessage(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1348,7 +1363,7 @@ func (gw *Gateway) getMessages(w http.ResponseWriter, r *http.Request) {
 		ThreadId: threadId,
 	}
 
-	resp, err := gw.client.GetMessages(r.Context(), req)
+	resp, err := gw.backend.GetMessages(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1391,7 +1406,7 @@ func (gw *Gateway) updateSessionState(w http.ResponseWriter, r *http.Request) {
 		Status:       reqBody.Status,
 	}
 
-	resp, err := gw.client.UpdateSessionState(r.Context(), req)
+	resp, err := gw.backend.UpdateSessionState(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1417,7 +1432,7 @@ func (gw *Gateway) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 		CheckpointNs: checkpointNs,
 	}
 
-	resp, err := gw.client.GetCheckpoint(r.Context(), req)
+	resp, err := gw.backend.GetCheckpoint(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1444,7 +1459,7 @@ func (gw *Gateway) putCheckpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := gw.client.PutCheckpoint(r.Context(), &req)
+	resp, err := gw.backend.PutCheckpoint(r.Context(), &req)
 	writeJSONResponse(w, resp, err)
 }
 
@@ -1474,6 +1489,6 @@ func (gw *Gateway) listCheckpoints(w http.ResponseWriter, r *http.Request) {
 		BeforeThreadId: beforeThreadId,
 	}
 
-	resp, err := gw.client.ListCheckpoints(r.Context(), req)
+	resp, err := gw.backend.ListCheckpoints(r.Context(), req)
 	writeJSONResponse(w, resp, err)
 }

--- a/backend/grpc_server.go
+++ b/backend/grpc_server.go
@@ -4,196 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
 	apipb "mealplanner/generated/go"
-	agentpb "mealplanner/generated/go/agent"
 	"mealplanner/logging"
-	"mealplanner/models"
 	"mealplanner/server"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var grpcServerLogger = logging.GetGrpcLogger("grpc-server")
-var agentClient agentpb.AgentServiceClient
-var agentConn *grpc.ClientConn
-
-// initAgentClient initializes the gRPC client connection to the agent service with retries
-func initAgentClient() error {
-	maxRetries := 5
-	baseDelay := 1 * time.Second
-
-	for i := 0; i < maxRetries; i++ {
-		start := time.Now()
-		grpcServerLogger.Infow("Attempting to connect to agent service",
-			"attempt", i+1,
-			"address", "localhost:50053")
-
-		// Use DialContext with timeout and WithBlock, just like the logging client
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		conn, err := grpc.DialContext(
-			ctx,
-			"localhost:50053",
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithBlock(),
-		)
-		cancel()
-
-		if err == nil {
-			agentConn = conn
-			agentClient = agentpb.NewAgentServiceClient(conn)
-			grpcServerLogger.Infow("Successfully connected to agent service",
-				"attempt", i+1,
-				"duration", time.Since(start).String())
-			return nil
-		}
-
-		if i < maxRetries-1 {
-			delay := time.Duration(i+1) * baseDelay
-			grpcServerLogger.Infow("Failed to connect to agent service, retrying",
-				"attempt", i+1,
-				"maxRetries", maxRetries,
-				"retryIn", delay.String(),
-				"error", err.Error())
-			time.Sleep(delay)
-		}
-	}
-
-	return fmt.Errorf("failed to connect to agent service after %d attempts", maxRetries)
-}
-
-// closeAgentClient closes the agent service connection
-func closeAgentClient() error {
-	if agentConn != nil {
-		err := agentConn.Close()
-		agentConn = nil
-		agentClient = nil
-		return err
-	}
-	return nil
-}
-
-// ensureAgentClient attempts to ensure we have a working agent client, with lazy retry
-func ensureAgentClient() error {
-	if agentClient != nil {
-		return nil
-	}
-
-	// Try to initialize with fewer retries for lazy loading
-	maxRetries := 3
-	baseDelay := 500 * time.Millisecond
-
-	for i := 0; i < maxRetries; i++ {
-		conn, err := grpc.Dial("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err == nil {
-			agentClient = agentpb.NewAgentServiceClient(conn)
-			grpcServerLogger.Infow("Lazy-initialized agent service connection", "attempt", i+1)
-			return nil
-		}
-
-		if i < maxRetries-1 {
-			delay := time.Duration(i+1) * baseDelay
-			time.Sleep(delay)
-		}
-	}
-
-	return fmt.Errorf("failed to lazy-initialize agent service connection after %d attempts", maxRetries)
-}
 
 type MealPlannerAPIServer struct {
 	apipb.UnimplementedMealPlannerAPIServer
-}
-
-// callAgentService makes a gRPC call to the agent service
-func callAgentService(ctx context.Context, method string, req interface{}) (models.AgentResponse, error) {
-	if agentClient == nil {
-		return models.AgentResponse{}, fmt.Errorf("agent client not initialized")
-	}
-
-	grpcServerLogger.Debugw("callAgentService: calling agent service", "method", method)
-
-	switch method {
-	case "plan_start":
-		if startReq, ok := req.(*agentpb.PlanStartRequest); ok {
-			// set deadline for the ctx
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			resp, err := agentClient.PlanStart(ctx, startReq)
-			cancel()
-			if err != nil {
-				grpcServerLogger.Errorw("callAgentService: plan start failed", "error", err)
-				return models.AgentResponse{}, fmt.Errorf("agent service plan start failed: %w", err)
-			}
-			// log out the whole result
-			grpcServerLogger.Infow("callAgentService: plan start response", "response", resp)
-			return models.AgentResponse{
-				Success:     resp.Success,
-				Message:     resp.Message,
-				ThreadID:    resp.ThreadId,
-				CurrentStep: resp.CurrentStep,
-				InitialState: func() map[string]interface{} {
-					if len(resp.InitialState) > 0 {
-						var state map[string]interface{}
-						if err := json.Unmarshal(resp.InitialState, &state); err == nil {
-							return state
-						}
-					}
-					return nil
-				}(),
-			}, nil
-		}
-	case "plan_feedback":
-		if feedbackReq, ok := req.(*agentpb.PlanFeedbackRequest); ok {
-			resp, err := agentClient.PlanFeedback(ctx, feedbackReq)
-			if err != nil {
-				grpcServerLogger.Errorw("callAgentService: plan feedback failed", "error", err)
-				return models.AgentResponse{}, fmt.Errorf("agent service plan feedback failed: %w", err)
-			}
-			return models.AgentResponse{
-				Success:     resp.Success,
-				Message:     resp.Message,
-				ThreadID:    "", // Not returned by feedback
-				CurrentStep: "",
-			}, nil
-		}
-	case "resume":
-		if resumeReq, ok := req.(*agentpb.ResumeWorkflowRequest); ok {
-			resp, err := agentClient.ResumeWorkflow(ctx, resumeReq)
-			if err != nil {
-				grpcServerLogger.Errorw("callAgentService: resume workflow failed", "error", err)
-				return models.AgentResponse{}, fmt.Errorf("agent service resume workflow failed: %w", err)
-			}
-			return models.AgentResponse{
-				Success:     resp.Success,
-				Message:     resp.Message,
-				ThreadID:    "", // Not returned by resume
-				CurrentStep: resp.CurrentStep,
-			}, nil
-		}
-	case "finalize":
-		if finalizeReq, ok := req.(*agentpb.PlanFinalizeRequest); ok {
-			resp, err := agentClient.PlanFinalize(ctx, finalizeReq)
-			if err != nil {
-				grpcServerLogger.Errorw("callAgentService: plan finalize failed", "error", err)
-				return models.AgentResponse{}, fmt.Errorf("agent service plan finalize failed: %w", err)
-			}
-			return models.AgentResponse{
-				Success:     resp.Success,
-				Message:     resp.Message,
-				ThreadID:    "", // Not returned by finalize
-				CurrentStep: "",
-			}, nil
-		}
-	default:
-		return models.AgentResponse{}, fmt.Errorf("unknown agent service method: %s", method)
-	}
-
-	return models.AgentResponse{}, fmt.Errorf("invalid request type for method: %s", method)
 }
 
 // joinParticipants converts a slice of participants to a comma-separated string
@@ -234,7 +58,6 @@ func buildShoppingList(mealIDs []int) ([]*apipb.ShoppingListItem, error) {
 
 func (s *MealPlannerAPIServer) HealthCheck(ctx context.Context, req *emptypb.Empty) (*apipb.HealthCheckResponse, error) {
 	dbHealthy := false
-	agentHealthy := false
 
 	// Check database health
 	if server.DB == nil {
@@ -252,30 +75,17 @@ func (s *MealPlannerAPIServer) HealthCheck(ctx context.Context, req *emptypb.Emp
 	}
 	dbHealthy = true
 
-	// Check agent service health - verify connection state
-	if agentClient != nil && agentConn != nil {
-		state := agentConn.GetState()
-		if state == connectivity.Ready || state == connectivity.Idle {
-			agentHealthy = true
-		}
-	}
-
-	if dbHealthy && agentHealthy {
+	if dbHealthy {
 		return &apipb.HealthCheckResponse{
 			Status:  "ok",
-			Message: "Database and agent service connected - service healthy",
-		}, nil
-	} else if dbHealthy {
-		return &apipb.HealthCheckResponse{
-			Status:  "degraded",
-			Message: "Database connected but agent service unavailable - limited functionality",
-		}, nil
-	} else {
-		return &apipb.HealthCheckResponse{
-			Status:  "error",
-			Message: "Database connection is healthy but agent service unavailable",
+			Message: "Database connected",
 		}, nil
 	}
+
+	return &apipb.HealthCheckResponse{
+		Status:  "error",
+		Message: "Database connection is not healthy",
+	}, nil
 }
 
 func (s *MealPlannerAPIServer) Reconnect(ctx context.Context, req *emptypb.Empty) (*apipb.ReconnectResponse, error) {
@@ -596,135 +406,6 @@ func (s *MealPlannerAPIServer) DeleteAllSteps(ctx context.Context, req *apipb.De
 
 	return &apipb.DeleteAllStepsResponse{
 		Message: "All steps deleted successfully",
-	}, nil
-}
-
-func (s *MealPlannerAPIServer) StartAgentWorkflow(ctx context.Context, req *apipb.StartAgentWorkflowRequest) (*apipb.StartAgentWorkflowResponse, error) {
-	if req.Request == nil {
-		return nil, fmt.Errorf("request is required")
-	}
-	if len(req.Request.Participants) == 0 {
-		return nil, fmt.Errorf("participants required")
-	}
-	if req.Request.WorkflowType == "" {
-		return nil, fmt.Errorf("workflow_type required")
-	}
-
-	// Convert to models format for CLI execution
-	startReq := models.AgentStartRequest{
-		Participants: req.Request.Participants,
-		WorkflowType: req.Request.WorkflowType,
-	}
-
-	ctxTimeout, cancel := context.WithTimeout(ctx, 25*time.Second)
-	defer cancel()
-
-	// Create agent service request
-	agentReq := &agentpb.PlanStartRequest{
-		Participants: startReq.Participants,
-	}
-
-	resp, err := callAgentService(ctxTimeout, "plan_start", agentReq)
-	if err != nil {
-		grpcServerLogger.Errorw("StartAgentWorkflow: agent service start failed", "error", err)
-		return nil, fmt.Errorf("agent service start failed: %w", err)
-	}
-
-	// Convert response to protobuf format
-	pbResp := &apipb.AgentResponse{
-		Success:     resp.Success,
-		Message:     resp.Message,
-		ThreadId:    resp.ThreadID,
-		CurrentStep: resp.CurrentStep,
-	}
-	// Initialize workflow checkpoint if thread ID returned
-	var stateMap map[string]interface{}
-	if resp.ThreadID != "" {
-		if resp.InitialState != nil {
-			if b, err := json.Marshal(resp.InitialState); err == nil {
-				_ = json.Unmarshal(b, &stateMap)
-			}
-			if stateMap == nil {
-				stateMap = map[string]interface{}{}
-			}
-			// Remove deprecated fields
-			delete(stateMap, "workflow_type")
-			delete(stateMap, "channel_values")
-
-			checkpoint := map[string]interface{}{
-				"state": stateMap,
-				"next":  []interface{}{},
-				"step":  0,
-			}
-			if data, err := json.Marshal(checkpoint); err == nil {
-				server.Services.WorkflowService.UpdateWorkflowCheckpoint(resp.ThreadID, data)
-				pbResp.InitialState = string(data)
-			}
-		}
-
-		// Add initial agent message if present
-		if resp.Message != "" {
-			t := time.Now().Format(time.RFC3339)
-			server.Services.WorkflowService.AddAgentMessage(resp.ThreadID, resp.Message, t)
-		}
-	}
-
-	return &apipb.StartAgentWorkflowResponse{
-		Response: pbResp,
-	}, nil
-}
-
-func (s *MealPlannerAPIServer) MessageAgent(ctx context.Context, req *apipb.MessageAgentRequest) (*apipb.MessageAgentResponse, error) {
-	if req.Request == nil {
-		return nil, fmt.Errorf("request is required")
-	}
-	if req.Request.ThreadId == "" {
-		return nil, fmt.Errorf("threadId required")
-	}
-	if req.Request.Message == "" {
-		return nil, fmt.Errorf("message required")
-	}
-	if req.Request.From == "" {
-		return nil, fmt.Errorf("from required")
-	}
-
-	ctxTimeout, cancel := context.WithTimeout(ctx, 25*time.Second)
-	defer cancel()
-
-	// Run feedback
-	feedbackReq := &agentpb.PlanFeedbackRequest{
-		ThreadId: req.Request.ThreadId,
-		Message:  req.Request.Message,
-		From:     req.Request.From,
-	}
-	_, err := callAgentService(ctxTimeout, "plan_feedback", feedbackReq)
-	if err != nil {
-		grpcServerLogger.Errorw("MessageAgent: agent service feedback failed", "error", err)
-		return nil, fmt.Errorf("agent service feedback failed: %w", err)
-	}
-
-	// Run resume
-	resumeReq := &agentpb.ResumeWorkflowRequest{
-		ThreadId: req.Request.ThreadId,
-	}
-	grpcServerLogger.Debugw("MessageAgent: invoking resume", "threadID", req.Request.ThreadId)
-	resp, err := callAgentService(ctxTimeout, "resume", resumeReq)
-	if err != nil {
-		grpcServerLogger.Errorw("MessageAgent: agent service resume failed", "error", err)
-		return nil, fmt.Errorf("agent service resume failed: %w", err)
-	}
-	grpcServerLogger.Debugw("MessageAgent: resume response", "threadID", req.Request.ThreadId, "success", resp.Success, "message", resp.Message, "currentStep", resp.CurrentStep)
-
-	// Convert response to protobuf format
-	pbResp := &apipb.AgentResponse{
-		Success:     resp.Success,
-		Message:     resp.Message,
-		ThreadId:    resp.ThreadID,
-		CurrentStep: resp.CurrentStep,
-	}
-
-	return &apipb.MessageAgentResponse{
-		Response: pbResp,
 	}, nil
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/joho/godotenv"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -88,13 +87,6 @@ func main() {
 		server.WorkflowService = server.Services.WorkflowService
 	}
 
-	// Initialize agent service client with retries (blocks until connected or max retries exceeded)
-	if err := initAgentClient(); err != nil {
-		mainLogger.Warnw("Failed to initialize agent client after retries, agent workflows will not work", "error", err)
-	} else {
-		mainLogger.Info("Agent service client initialized successfully")
-	}
-
 	// Start gRPC server (HTTP server removed as part of gRPC migration)
 	lis, err := net.Listen("tcp", ":50051")
 	if err != nil {
@@ -111,11 +103,10 @@ func main() {
 	healthServer := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
 
-	// Set health status based on database and agent service connectivity
+	// Set health status based on database connectivity
 	var healthStatus grpc_health_v1.HealthCheckResponse_ServingStatus
 	dbHealthy := false
-	agentHealthy := false
-	
+
 	// Check database health
 	if connection != nil {
 		if err := connection.Ping(); err == nil {
@@ -126,31 +117,13 @@ func main() {
 	} else {
 		mainLogger.Warn("Health check: No database connection")
 	}
-	
-	// Check agent service health - verify connection state
-	if agentClient != nil && agentConn != nil {
-		state := agentConn.GetState()
-		if state == connectivity.Ready || state == connectivity.Idle {
-			agentHealthy = true
-		} else {
-			mainLogger.Warnw("Health check: Agent connection not ready", "state", state.String())
-		}
-	} else {
-		mainLogger.Warn("Health check: No agent service connection")
-	}
-	
-	if dbHealthy && agentHealthy {
+
+	if dbHealthy {
 		healthStatus = grpc_health_v1.HealthCheckResponse_SERVING
-		mainLogger.Info("Health check: Database and agent service connected - service SERVING")
+		mainLogger.Info("Health check: Database connected - service SERVING")
 	} else {
 		healthStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
-		if !dbHealthy && !agentHealthy {
-			mainLogger.Warn("Health check: Database and agent service not connected - service NOT_SERVING")
-		} else if !dbHealthy {
-			mainLogger.Warn("Health check: Database not connected - service NOT_SERVING")
-		} else {
-			mainLogger.Warn("Health check: Agent service not connected - service NOT_SERVING")
-		}
+		mainLogger.Warn("Health check: Database not connected - service NOT_SERVING")
 	}
 
 	healthServer.SetServingStatus("mealplanner.api.MealPlannerAPI", healthStatus)
@@ -164,8 +137,7 @@ func main() {
 		for range ticker.C {
 			var currentStatus grpc_health_v1.HealthCheckResponse_ServingStatus
 			dbHealthy := false
-			agentHealthy := false
-			
+
 			// Check database health
 			if server.DB != nil {
 				if err := server.DB.Ping(); err == nil {
@@ -176,30 +148,12 @@ func main() {
 			} else {
 				mainLogger.Warn("Health check: No database connection")
 			}
-			
-			// Check agent service health - verify connection state
-			if agentClient != nil && agentConn != nil {
-				state := agentConn.GetState()
-				if state == connectivity.Ready || state == connectivity.Idle {
-					agentHealthy = true
-				} else {
-					mainLogger.Warnw("Health check: Agent connection not ready", "state", state.String())
-				}
-			} else {
-				mainLogger.Warn("Health check: No agent service connection")
-			}
-			
-			if dbHealthy && agentHealthy {
+
+			if dbHealthy {
 				currentStatus = grpc_health_v1.HealthCheckResponse_SERVING
 			} else {
 				currentStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
-				if !dbHealthy && !agentHealthy {
-					mainLogger.Warn("Health check: Database and agent service not connected")
-				} else if !dbHealthy {
-					mainLogger.Warn("Health check: Database not connected")
-				} else {
-					mainLogger.Warn("Health check: Agent service not connected")
-				}
+				mainLogger.Warn("Health check: Database not connected")
 			}
 
 			// Update health status if it changed

--- a/generated/go/agent/agent_grpc.pb.go
+++ b/generated/go/agent/agent_grpc.pb.go
@@ -11,6 +11,7 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	apipb "mealplanner/generated/go"
 )
 
 // This is a compile-time assertion to ensure that this generated file
@@ -19,10 +20,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	AgentService_PlanStart_FullMethodName      = "/agent.AgentService/PlanStart"
-	AgentService_PlanFeedback_FullMethodName   = "/agent.AgentService/PlanFeedback"
-	AgentService_PlanFinalize_FullMethodName   = "/agent.AgentService/PlanFinalize"
-	AgentService_ResumeWorkflow_FullMethodName = "/agent.AgentService/ResumeWorkflow"
+	AgentService_PlanStart_FullMethodName          = "/agent.AgentService/PlanStart"
+	AgentService_PlanFeedback_FullMethodName       = "/agent.AgentService/PlanFeedback"
+	AgentService_PlanFinalize_FullMethodName       = "/agent.AgentService/PlanFinalize"
+	AgentService_ResumeWorkflow_FullMethodName     = "/agent.AgentService/ResumeWorkflow"
+	AgentService_StartAgentWorkflow_FullMethodName = "/agent.AgentService/StartAgentWorkflow"
+	AgentService_MessageAgent_FullMethodName       = "/agent.AgentService/MessageAgent"
 )
 
 // AgentServiceClient is the client API for AgentService service.
@@ -37,6 +40,8 @@ type AgentServiceClient interface {
 	PlanFinalize(ctx context.Context, in *PlanFinalizeRequest, opts ...grpc.CallOption) (*PlanFinalizeResponse, error)
 	// Workflow management
 	ResumeWorkflow(ctx context.Context, in *ResumeWorkflowRequest, opts ...grpc.CallOption) (*ResumeWorkflowResponse, error)
+	StartAgentWorkflow(ctx context.Context, in *apipb.StartAgentWorkflowRequest, opts ...grpc.CallOption) (*apipb.StartAgentWorkflowResponse, error)
+	MessageAgent(ctx context.Context, in *apipb.MessageAgentRequest, opts ...grpc.CallOption) (*apipb.MessageAgentResponse, error)
 }
 
 type agentServiceClient struct {
@@ -87,6 +92,26 @@ func (c *agentServiceClient) ResumeWorkflow(ctx context.Context, in *ResumeWorkf
 	return out, nil
 }
 
+func (c *agentServiceClient) StartAgentWorkflow(ctx context.Context, in *apipb.StartAgentWorkflowRequest, opts ...grpc.CallOption) (*apipb.StartAgentWorkflowResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(apipb.StartAgentWorkflowResponse)
+	err := c.cc.Invoke(ctx, AgentService_StartAgentWorkflow_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentServiceClient) MessageAgent(ctx context.Context, in *apipb.MessageAgentRequest, opts ...grpc.CallOption) (*apipb.MessageAgentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(apipb.MessageAgentResponse)
+	err := c.cc.Invoke(ctx, AgentService_MessageAgent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AgentServiceServer is the server API for AgentService service.
 // All implementations must embed UnimplementedAgentServiceServer
 // for forward compatibility.
@@ -99,6 +124,8 @@ type AgentServiceServer interface {
 	PlanFinalize(context.Context, *PlanFinalizeRequest) (*PlanFinalizeResponse, error)
 	// Workflow management
 	ResumeWorkflow(context.Context, *ResumeWorkflowRequest) (*ResumeWorkflowResponse, error)
+	StartAgentWorkflow(context.Context, *apipb.StartAgentWorkflowRequest) (*apipb.StartAgentWorkflowResponse, error)
+	MessageAgent(context.Context, *apipb.MessageAgentRequest) (*apipb.MessageAgentResponse, error)
 	mustEmbedUnimplementedAgentServiceServer()
 }
 
@@ -120,6 +147,12 @@ func (UnimplementedAgentServiceServer) PlanFinalize(context.Context, *PlanFinali
 }
 func (UnimplementedAgentServiceServer) ResumeWorkflow(context.Context, *ResumeWorkflowRequest) (*ResumeWorkflowResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ResumeWorkflow not implemented")
+}
+func (UnimplementedAgentServiceServer) StartAgentWorkflow(context.Context, *apipb.StartAgentWorkflowRequest) (*apipb.StartAgentWorkflowResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartAgentWorkflow not implemented")
+}
+func (UnimplementedAgentServiceServer) MessageAgent(context.Context, *apipb.MessageAgentRequest) (*apipb.MessageAgentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MessageAgent not implemented")
 }
 func (UnimplementedAgentServiceServer) mustEmbedUnimplementedAgentServiceServer() {}
 func (UnimplementedAgentServiceServer) testEmbeddedByValue()                      {}
@@ -214,6 +247,42 @@ func _AgentService_ResumeWorkflow_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentService_StartAgentWorkflow_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(apipb.StartAgentWorkflowRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServiceServer).StartAgentWorkflow(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentService_StartAgentWorkflow_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServiceServer).StartAgentWorkflow(ctx, req.(*apipb.StartAgentWorkflowRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentService_MessageAgent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(apipb.MessageAgentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServiceServer).MessageAgent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentService_MessageAgent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServiceServer).MessageAgent(ctx, req.(*apipb.MessageAgentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AgentService_ServiceDesc is the grpc.ServiceDesc for AgentService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -236,6 +305,14 @@ var AgentService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ResumeWorkflow",
 			Handler:    _AgentService_ResumeWorkflow_Handler,
+		},
+		{
+			MethodName: "StartAgentWorkflow",
+			Handler:    _AgentService_StartAgentWorkflow_Handler,
+		},
+		{
+			MethodName: "MessageAgent",
+			Handler:    _AgentService_MessageAgent_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -6,6 +6,7 @@ option go_package = "mealplanner/generated/go/agentpb";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
+import "api.proto";
 
 // Agent Service - provides gRPC endpoints for all CLI commands
 service AgentService {
@@ -16,6 +17,10 @@ service AgentService {
   
   // Workflow management
   rpc ResumeWorkflow(ResumeWorkflowRequest) returns (ResumeWorkflowResponse);
+
+  // High level workflow endpoints for API gateway
+  rpc StartAgentWorkflow(mealplanner.api.StartAgentWorkflowRequest) returns (mealplanner.api.StartAgentWorkflowResponse);
+  rpc MessageAgent(mealplanner.api.MessageAgentRequest) returns (mealplanner.api.MessageAgentResponse);
 }
 
 // Plan Start

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -543,9 +543,7 @@ service MealPlannerAPI {
   rpc ReorderSteps(ReorderStepsRequest) returns (ReorderStepsResponse);
   rpc DeleteAllSteps(DeleteAllStepsRequest) returns (DeleteAllStepsResponse);
 
-  // Agent workflow endpoints
-  rpc StartAgentWorkflow(StartAgentWorkflowRequest) returns (StartAgentWorkflowResponse);
-  rpc MessageAgent(MessageAgentRequest) returns (MessageAgentResponse);
+  // Agent workflow endpoints handled by the agent service
   rpc GetWorkflowStatus(GetWorkflowStatusRequest) returns (GetWorkflowStatusResponse);
   rpc ListWorkflows(google.protobuf.Empty) returns (ListWorkflowsResponse);
   rpc CancelWorkflow(CancelWorkflowRequest) returns (CancelWorkflowResponse);


### PR DESCRIPTION
## Summary
- shift StartAgentWorkflow and MessageAgent RPCs from backend to agent service
- add StartAgentWorkflow and MessageAgent handlers in agent service
- update proto definitions and generated client
- refactor API gateway to call agent service directly
- remove agent service client logic from backend

## Testing
- `yarn test` *(fails: Frontend tests and agent tests could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_687afe84a5288324bdf7a3e6981412f9