### PR TITLE
Add toggle for verbose meal plan logging

### DIFF
--- a/meal-service/logging/logging.go
+++ b/meal-service/logging/logging.go
@@ -17,7 +17,21 @@ var (
 	loggerOnce sync.Once
 	grpcLogger *logger.LoggingClient
 	useGrpcLog bool
+	verbose    bool
 )
+
+// IsVerbose returns true if verbose logging is enabled.
+func IsVerbose() bool {
+	InitLogger()
+	return verbose
+}
+
+// ResetForTest clears the logger so it can be reinitialized. For use in tests only.
+func ResetForTest() {
+	Logger = nil
+	loggerOnce = sync.Once{}
+	verbose = false
+}
 
 // GetLogger returns a named SugaredLogger, initializing the logger if necessary.
 func GetLogger(name string) *zap.SugaredLogger {
@@ -63,6 +77,11 @@ func GetGrpcLogger(name string) *zap.SugaredLogger {
 // InitLogger initializes the global structured logger (zap) for the application.
 func InitLogger() {
 	loggerOnce.Do(func() {
+		// Determine if verbose logging is enabled via env var
+		if v := strings.ToLower(os.Getenv("VERBOSE_MEAL_PLAN_LOGS")); v == "true" || v == "1" {
+			verbose = true
+		}
+
 		// Check if we should use gRPC logging
 		loggingServiceAddr := os.Getenv("LOGGING_SERVICE_ADDR")
 		if loggingServiceAddr == "" {

--- a/meal-service/logging/logging_test.go
+++ b/meal-service/logging/logging_test.go
@@ -1,0 +1,21 @@
+package logging
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsVerboseDefaultFalse(t *testing.T) {
+	os.Unsetenv("VERBOSE_MEAL_PLAN_LOGS")
+	ResetForTest()
+	assert.False(t, IsVerbose())
+}
+
+func TestIsVerboseEnvVar(t *testing.T) {
+	os.Setenv("VERBOSE_MEAL_PLAN_LOGS", "true")
+	ResetForTest()
+	assert.True(t, IsVerbose())
+	os.Unsetenv("VERBOSE_MEAL_PLAN_LOGS")
+}

--- a/meal-service/models/mealplan.go
+++ b/meal-service/models/mealplan.go
@@ -76,15 +76,17 @@ func GenerateWeeklyMealPlan(db *sql.DB) (*WeeklyMealPlan, error) {
 	// log dayIndex for the 8th meal
 	mealPlanServiceLogger.Debugw("In the model, 8th meal", "dayIndex", plan.Days[7].DayIndex)
 
-	// DEBUGGING: Log all dayIndex values after generation
-	mealPlanServiceLogger.Infow("🔍 [BACKEND] GenerateWeeklyMealPlan complete - dayIndex values:")
-	for i, day := range plan.Days {
-		mealPlanServiceLogger.Infow("🔍 [BACKEND] Meal entry", "index", i, "dayIndex", day.DayIndex, "mealType", day.MealType, "mealName", func() string {
-			if day.Meal != nil {
-				return day.Meal.Name
-			}
-			return "nil"
-		}())
+	if logging.IsVerbose() {
+		// DEBUGGING: Log all dayIndex values after generation
+		mealPlanServiceLogger.Infow("🔍 [BACKEND] GenerateWeeklyMealPlan complete - dayIndex values:")
+		for i, day := range plan.Days {
+			mealPlanServiceLogger.Infow("🔍 [BACKEND] Meal entry", "index", i, "dayIndex", day.DayIndex, "mealType", day.MealType, "mealName", func() string {
+				if day.Meal != nil {
+					return day.Meal.Name
+				}
+				return "nil"
+			}())
+		}
 	}
 
 	return plan, nil
@@ -239,8 +241,6 @@ func getLastPlannedMealsByType(db *sql.DB, mealType string, limit int) ([]*Meal,
 	return meals, nil
 }
 
-
-
 // RemoveMealFromPlan sets the specified meal slot to nil in the weekly plan.
 // dayIndex should be 0=Monday .. 6=Sunday. mealType should be breakfast, lunch, or dinner.
 func RemoveMealFromPlan(plan *WeeklyMealPlan, dayIndex int, mealType string) error {
@@ -267,4 +267,3 @@ func RemoveMealFromPlan(plan *WeeklyMealPlan, dayIndex int, mealType string) err
 	}
 	return fmt.Errorf("meal not found for dayIndex %d and mealType %s", dayIndex, mealType)
 }
-


### PR DESCRIPTION
## Summary
- allow verbose logging to be toggled by `VERBOSE_MEAL_PLAN_LOGS`
- log weekly meal plan only when verbose logging is enabled
- provide logger reset helper for tests
- add tests for verbose flag

## Testing
- `yarn test` *(fails: Agent tests unable to connect to services)*
- `yarn test:agent` *(fails: ConnectError ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_687bfad32c788324b3b2286692a931e8