### PR TITLE
Add frontend health check reconnect flow

### DIFF
--- a/api-gateway/docs/docs.go
+++ b/api-gateway/docs/docs.go
@@ -372,7 +372,7 @@ const docTemplate = `{
         },
         "/health": {
             "get": {
-                "description": "Check the health status of the API gateway and backend services",
+                "description": "Check the health status of the API gateway and all backend services",
                 "consumes": [
                     "application/json"
                 ],
@@ -2173,6 +2173,12 @@ const docTemplate = `{
             "properties": {
                 "message": {
                     "type": "string"
+                },
+                "services": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "status": {
                     "type": "string"

--- a/api-gateway/docs/swagger.json
+++ b/api-gateway/docs/swagger.json
@@ -366,7 +366,7 @@
         },
         "/health": {
             "get": {
-                "description": "Check the health status of the API gateway and backend services",
+                "description": "Check the health status of the API gateway and all backend services",
                 "consumes": [
                     "application/json"
                 ],
@@ -2167,6 +2167,12 @@
             "properties": {
                 "message": {
                     "type": "string"
+                },
+                "services": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "status": {
                     "type": "string"

--- a/api-gateway/docs/swagger.yaml
+++ b/api-gateway/docs/swagger.yaml
@@ -392,6 +392,10 @@ definitions:
     properties:
       message:
         type: string
+      services:
+        additionalProperties:
+          type: boolean
+        type: object
       status:
         type: string
     type: object
@@ -827,7 +831,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Check the health status of the API gateway and backend services
+      description: Check the health status of the API gateway and all backend services
       produces:
       - application/json
       responses:

--- a/generated/ts/gateway/sdk.gen.ts
+++ b/generated/ts/gateway/sdk.gen.ts
@@ -120,7 +120,7 @@ export const getCheckpointsByThreadId = <ThrowOnError extends boolean = false>(o
 
 /**
  * Health Check
- * Check the health status of the API gateway and backend services
+ * Check the health status of the API gateway and all backend services
  */
 export const getHealth = <ThrowOnError extends boolean = false>(options?: Options<GetHealthData, ThrowOnError>) => {
     return (options?.client ?? _heyApiClient).get<GetHealthResponses, GetHealthErrors, ThrowOnError>({

--- a/generated/ts/gateway/types.gen.ts
+++ b/generated/ts/gateway/types.gen.ts
@@ -246,6 +246,9 @@ export type MainGetMessagesResponse = {
 
 export type MainHealthResponse = {
     message?: string;
+    services?: {
+        [key: string]: boolean;
+    };
     status?: string;
 };
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -63,6 +63,14 @@ try {
 // Step 2: Start services in the correct order (matching e2e test)
 let loggingProcess, backendProcess, gatewayProcess, mcpProcess, agentProcess, frontendProcess;
 
+// Start frontend immediately - health check will handle service readiness
+console.log(chalk.blue('🚀 Starting frontend...'));
+frontendProcess = spawn('yarn', ['start'], {
+  cwd: path.join(PROJECT_ROOT, 'ui'),
+  stdio: 'inherit',
+  shell: true,
+});
+
 // Start logging service first
 console.log(chalk.blue('🚀 Starting logging service...'));
 loggingProcess = spawn('go', ['run', '.'], {
@@ -103,26 +111,16 @@ agentProcess = spawn('yarn', ['start:grpc'], {
   shell: true,
 });
 
-// Wait a bit for all services to initialize, then start frontend
-setTimeout(() => {
-  console.log(chalk.blue('🚀 Starting frontend...'));
-  frontendProcess = spawn('yarn', ['start'], {
-    cwd: path.join(PROJECT_ROOT, 'ui'),
-    stdio: 'inherit',
-    shell: true,
-  });
+// Handle frontend process events
+frontendProcess.on('error', (error) => {
+  console.error(chalk.red('❌ Failed to start frontend:'), error.message);
+  process.exit(1);
+});
 
-  // Handle frontend process events
-  frontendProcess.on('error', (error) => {
-    console.error(chalk.red('❌ Failed to start frontend:'), error.message);
-    process.exit(1);
-  });
-
-  frontendProcess.on('close', (code) => {
-    console.log(chalk.blue(`Frontend exited with code ${code}`));
-    process.exit(code);
-  });
-}, 5000); // Wait 5 seconds for all backend services to initialize
+frontendProcess.on('close', (code) => {
+  console.log(chalk.blue(`Frontend exited with code ${code}`));
+  process.exit(code);
+});
 
 // Handle process events
 loggingProcess.on('error', (error) => {

--- a/ui/src/AgentPage.tsx
+++ b/ui/src/AgentPage.tsx
@@ -458,13 +458,13 @@ const AgentPage: React.FC = () => {
       localStorage.setItem('sessionId', result.session.threadId);
 
       // Extract meal plan from initial state
-      if (result.initialState?.state?.mealPlan) {
+      if (result.initialState?.mealPlan) {
         console.log(
           'Setting meal plan from session start:',
-          result.initialState.state.mealPlan,
+          result.initialState.mealPlan,
         );
-        setMealPlan(result.initialState.state.mealPlan);
-        setShoppingList(result.initialState.state.mealPlan.shoppingList);
+        setMealPlan(result.initialState.mealPlan);
+        setShoppingList(result.initialState.mealPlan.shoppingList);
       }
 
       if (result.message) {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import App from './App';
+import '@testing-library/jest-dom';
+
+jest.mock('@mealplanner/generated/dist/gateway/client/index.js', () => ({
+  createClient: jest.fn(() => ({})),
+  createConfig: jest.fn(() => ({})),
+}));
+
+jest.mock('@mealplanner/generated/dist/gateway/sdk.gen', () => ({
+  getHealth: jest.fn(),
+  postReconnect: jest.fn(),
+}));
+
+import { getHealth } from '@mealplanner/generated/dist/gateway/sdk.gen';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders AgentPage when backend is healthy', async () => {
+  (getHealth as jest.Mock).mockResolvedValue({
+    data: { status: 'ok', services: { backend: true } },
+    error: undefined,
+  });
+
+  render(<App />);
+
+  await waitFor(() =>
+    expect(screen.getByTestId('start-session')).toBeInTheDocument(),
+  );
+});
+
+test('shows error page when health check fails', async () => {
+  (getHealth as jest.Mock).mockRejectedValue(new Error('fail'));
+
+  render(<App />);
+
+  await waitFor(() =>
+    expect(screen.getByText('Database Connection Error')).toBeInTheDocument(),
+  );
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef, useState } from 'react';
+import AgentPage from './AgentPage';
+import Connecting from './components/Connecting';
+import { DatabaseConnectionError } from './components/DatabaseConnectionError';
+import {
+  createClient,
+  createConfig,
+} from '@mealplanner/generated/dist/gateway/client/index.js';
+import {
+  getHealth,
+  postReconnect,
+} from '@mealplanner/generated/dist/gateway/sdk.gen';
+
+const gatewayClient = createClient(
+  createConfig({
+    baseUrl: 'http://localhost:8080/api',
+  }),
+);
+
+const POLL_INTERVAL = 3000;
+
+const App: React.FC = () => {
+  const [healthy, setHealthy] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const [services, setServices] = useState<
+    Record<string, boolean> | undefined
+  >();
+  const pollRef = useRef<NodeJS.Timeout>();
+
+  const checkHealth = async () => {
+    try {
+      const result = await getHealth({ client: gatewayClient });
+      if (result.data && !result.error) {
+        setServices(result.data.services);
+        const ok = Object.values(result.data.services || {}).every(Boolean);
+        setHealthy(ok);
+        setChecking(false);
+        return ok;
+      }
+    } catch {
+      // ignore
+    }
+    setHealthy(false);
+    setChecking(false);
+    return false;
+  };
+
+  useEffect(() => {
+    checkHealth();
+    pollRef.current = setInterval(async () => {
+      const ok = await checkHealth();
+      if (ok && pollRef.current) {
+        clearInterval(pollRef.current);
+      }
+    }, POLL_INTERVAL);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const handleRetry = async () => {
+    await postReconnect({ client: gatewayClient });
+    setChecking(true);
+    await checkHealth();
+  };
+
+  if (healthy) return <AgentPage />;
+  if (checking) return <Connecting services={services} />;
+  return <DatabaseConnectionError onRetry={handleRetry} services={services} />;
+};
+
+export default App;

--- a/ui/src/api/agentApi.ts
+++ b/ui/src/api/agentApi.ts
@@ -1,4 +1,4 @@
-import { AgentCheckpoint } from '@mealplanner/generated';
+import { AgentCheckpoint, MealPlanningCheckpointState } from '@mealplanner/generated';
 import {
   createClient,
   createConfig,
@@ -29,7 +29,7 @@ export interface SessionInfo {
 
 export interface StartSessionResult {
   session: SessionInfo;
-  initialState?: AgentCheckpoint;
+  initialState?: MealPlanningCheckpointState;
   message?: string;
 }
 
@@ -77,6 +77,7 @@ export async function startAgentSession(
     currentStep: agentResponse.currentStep,
   };
 
+  debugger
   let initialState;
   if (agentResponse.initialState) {
     try {

--- a/ui/src/components/Connecting.tsx
+++ b/ui/src/components/Connecting.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+
+interface ConnectingProps {
+  services?: Record<string, boolean>;
+}
+
+const Connecting: React.FC<ConnectingProps> = ({ services }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        gap: 2,
+      }}
+    >
+      <CircularProgress />
+      <Typography variant="h6">Connecting to server...</Typography>
+      {services && (
+        <Box>
+          {Object.entries(services).map(([name, ok]) => (
+            <Typography
+              key={name}
+              color={ok ? 'success.main' : 'error.main'}
+              variant="body2"
+            >
+              {name}: {ok ? 'healthy' : 'unhealthy'}
+            </Typography>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default Connecting;

--- a/ui/src/components/DatabaseConnectionError.tsx
+++ b/ui/src/components/DatabaseConnectionError.tsx
@@ -18,6 +18,7 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 interface DatabaseConnectionErrorProps {
   onRetry: () => Promise<void>;
+  services?: Record<string, boolean>;
 }
 
 export const DatabaseConnectionError: React.FC<
@@ -116,6 +117,20 @@ export const DatabaseConnectionError: React.FC<
           >
             Database Connection Error
           </Typography>
+
+          {services && (
+            <Box sx={{ mb: 2 }}>
+              {Object.entries(services).map(([name, ok]) => (
+                <Typography
+                  key={name}
+                  color={ok ? 'success.main' : 'error.main'}
+                  variant="body2"
+                >
+                  {name}: {ok ? 'healthy' : 'unhealthy'}
+                </Typography>
+              ))}
+            </Box>
+          )}
 
           <Alert
             severity="error"

--- a/ui/src/components/DatabaseConnectionError.tsx
+++ b/ui/src/components/DatabaseConnectionError.tsx
@@ -23,7 +23,7 @@ interface DatabaseConnectionErrorProps {
 
 export const DatabaseConnectionError: React.FC<
   DatabaseConnectionErrorProps
-> = ({ onRetry }) => {
+> = ({ onRetry, services }) => {
   const theme = useTheme();
   const [isRetrying, setIsRetrying] = useState(false);
 

--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -91,7 +91,7 @@ describe('index.tsx', () => {
     const cssBaseline = themeProvider.props.children[0];
     const app = themeProvider.props.children[1];
     expect(cssBaseline.type.name).toBe('CssBaseline');
-    expect(app.type.name).toBe('AgentPage');
+    expect(app.type.name).toBe('App');
   });
 
   it('renders agent page when path starts with /agent', () => {
@@ -106,7 +106,7 @@ describe('index.tsx', () => {
     const renderCall = mockRender.mock.calls[0][0];
     const themeProvider = renderCall.props.children;
     const page = themeProvider.props.children[1];
-    expect(page.type.name).toBe('AgentPage');
+    expect(page.type.name).toBe('App');
   });
 
   it('handles missing root element gracefully', () => {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import AgentPage from './AgentPage';
+import App from './App';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from './theme';
@@ -23,7 +23,7 @@ try {
     <React.StrictMode>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <AgentPage />
+        <App />
       </ThemeProvider>
     </React.StrictMode>,
   );


### PR DESCRIPTION
## Summary
- show a connecting screen while polling API health
- show DatabaseConnectionError with service statuses if the API is unhealthy
- stop polling once healthy and render the agent page
- adjust index to use new `App` component
- test the new behaviour

## Testing
- `yarn test` *(fails: Frontend and agent tests)*

------
https://chatgpt.com/codex/tasks/task_e_687bfac2d8a88324b932a63153ef4793